### PR TITLE
feat: add Nakama score summary and leaderboard flow

### DIFF
--- a/LifeSimulation/Assets/Editor.meta
+++ b/LifeSimulation/Assets/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 69d5bfbf92b0f1d43b354eef50969d65
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/LifeSimulation/Assets/Editor/EnforceHttpDownloadsSetting.cs
+++ b/LifeSimulation/Assets/Editor/EnforceHttpDownloadsSetting.cs
@@ -1,0 +1,43 @@
+// -----------------------------------------------------------------------------
+// Project:		EXTENDED LIFE SIMULATION CAPSTONE ASSIGNMENT
+// Item:		Editor Settings Utility
+// Requirement:	Leaderboard HTTP
+// Author:		Benjamin Jones
+// Date:		04/14/2026
+// Version:		0.0.0
+//
+// Description:
+//    Ensures Unity Player setting "Allow downloads over HTTP" stays enabled
+//    for Nakama HTTP integration during development.
+// -----------------------------------------------------------------------------
+
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEngine;
+
+/// <summary> Forces Allow downloads over HTTP to Always Allowed. </summary>
+public static class EnforceHttpDownloadsSetting
+{
+    [InitializeOnLoadMethod]
+    private static void ApplyOnEditorLoad()
+    {
+        ApplySetting();
+    }
+
+    [MenuItem("Tools/Leaderboard/Enable HTTP Downloads")]
+    private static void ApplyFromMenu()
+    {
+        ApplySetting();
+        Debug.Log("Player setting updated: Allow downloads over HTTP = Always Allowed.");
+    }
+
+    private static void ApplySetting()
+    {
+        if (PlayerSettings.insecureHttpOption != InsecureHttpOption.AlwaysAllowed)
+        {
+            PlayerSettings.insecureHttpOption = InsecureHttpOption.AlwaysAllowed;
+            AssetDatabase.SaveAssets();
+        }
+    }
+}
+#endif

--- a/LifeSimulation/Assets/Editor/EnforceHttpDownloadsSetting.cs
+++ b/LifeSimulation/Assets/Editor/EnforceHttpDownloadsSetting.cs
@@ -7,8 +7,8 @@
 // Version:		0.0.0
 //
 // Description:
-//    Ensures Unity Player setting "Allow downloads over HTTP" stays enabled
-//    for Nakama HTTP integration during development.
+//    Editor-only guard so Unity allows plain HTTP (e.g. local Nakama on :7350);
+//    without it UnityWebRequest can throw before requests leave the client.
 // -----------------------------------------------------------------------------
 
 #if UNITY_EDITOR

--- a/LifeSimulation/Assets/Editor/EnforceHttpDownloadsSetting.cs.meta
+++ b/LifeSimulation/Assets/Editor/EnforceHttpDownloadsSetting.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c929de62a0c50034382717f0a95c8af8

--- a/LifeSimulation/Assets/Scenes/ScoreSummary.unity
+++ b/LifeSimulation/Assets/Scenes/ScoreSummary.unity
@@ -1,0 +1,1540 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 2
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &105088783
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 105088784}
+  - component: {fileID: 105088786}
+  - component: {fileID: 105088785}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &105088784
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 105088783}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1878376568}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &105088785
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 105088783}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.4431373, g: 0.62352943, b: 0.6784314, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &105088786
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 105088783}
+  m_CullTransparentMesh: 1
+--- !u!1 &498381494
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 498381497}
+  - component: {fileID: 498381496}
+  - component: {fileID: 498381495}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &498381495
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 498381494}
+  m_Enabled: 1
+--- !u!20 &498381496
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 498381494}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &498381497
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 498381494}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &566712620
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 566712621}
+  - component: {fileID: 566712623}
+  - component: {fileID: 566712622}
+  m_Layer: 5
+  m_Name: ScoreSummaryPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &566712621
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 566712620}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 804427457}
+  - {fileID: 1549124416}
+  - {fileID: 695527908}
+  - {fileID: 1642049352}
+  m_Father: {fileID: 1878376568}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 500, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &566712622
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 566712620}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.4431373, g: 0.62352943, b: 0.6784314, a: 0.392}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &566712623
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 566712620}
+  m_CullTransparentMesh: 1
+--- !u!1 &695527907
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 695527908}
+  - component: {fileID: 695527911}
+  - component: {fileID: 695527910}
+  - component: {fileID: 695527909}
+  m_Layer: 5
+  m_Name: Quit
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &695527908
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 695527907}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1749250816}
+  m_Father: {fileID: 566712621}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 120, y: -200}
+  m_SizeDelta: {x: 220, y: 73}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &695527909
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 695527907}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 695527910}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2010020002}
+        m_TargetAssemblyTypeName: ScoreSummaryHandler, Assembly-CSharp
+        m_MethodName: QuitWithoutSubmitting
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &695527910
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 695527907}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &695527911
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 695527907}
+  m_CullTransparentMesh: 1
+--- !u!1 &804427456
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 804427457}
+  - component: {fileID: 804427459}
+  - component: {fileID: 804427458}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &804427457
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 804427456}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 566712621}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 250}
+  m_SizeDelta: {x: 450, y: 75}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &804427458
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 804427456}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Score Summary
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 52
+  m_fontSizeBase: 52
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &804427459
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 804427456}
+  m_CullTransparentMesh: 1
+--- !u!1 &1549124415
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1549124416}
+  - component: {fileID: 1549124419}
+  - component: {fileID: 1549124418}
+  - component: {fileID: 1549124417}
+  m_Layer: 5
+  m_Name: Submit
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1549124416
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1549124415}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1080879587}
+  m_Father: {fileID: 566712621}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -120, y: -200}
+  m_SizeDelta: {x: 220, y: 73}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1549124417
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1549124415}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1549124418}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2010020002}
+        m_TargetAssemblyTypeName: ScoreSummaryHandler, Assembly-CSharp
+        m_MethodName: SubmitAndQuit
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1549124418
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1549124415}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1549124419
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1549124415}
+  m_CullTransparentMesh: 1
+--- !u!1 &1080879586
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1080879587}
+  - component: {fileID: 1080879589}
+  - component: {fileID: 1080879588}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1080879587
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1080879586}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1549124416}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1080879588
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1080879586}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Submit
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1080879589
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1080879586}
+  m_CullTransparentMesh: 1
+--- !u!1 &1642049351
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1642049352}
+  - component: {fileID: 1642049355}
+  - component: {fileID: 1642049354}
+  - component: {fileID: 1642049353}
+  m_Layer: 5
+  m_Name: Row1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1642049352
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1642049351}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1888697420}
+  m_Father: {fileID: 566712621}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 140}
+  m_SizeDelta: {x: 400, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1642049353
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1642049351}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1642049354}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1642049354
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1642049351}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1642049355
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1642049351}
+  m_CullTransparentMesh: 1
+--- !u!1 &1749250815
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1749250816}
+  - component: {fileID: 1749250818}
+  - component: {fileID: 1749250817}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1749250816
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1749250815}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 695527908}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1749250817
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1749250815}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Quit
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1749250818
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1749250815}
+  m_CullTransparentMesh: 1
+--- !u!1 &1878376564
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1878376568}
+  - component: {fileID: 1878376567}
+  - component: {fileID: 1878376566}
+  - component: {fileID: 1878376565}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1878376565
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1878376564}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.GraphicRaycaster
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &1878376566
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1878376564}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.CanvasScaler
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &1878376567
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1878376564}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &1878376568
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1878376564}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 105088784}
+  - {fileID: 566712621}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!1 &1888697419
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1888697420}
+  - component: {fileID: 1888697422}
+  - component: {fileID: 1888697421}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1888697420
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1888697419}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1642049352}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1888697421
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1888697419}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Overall Score: 0
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 28
+  m_fontSizeBase: 28
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1888697422
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1888697419}
+  m_CullTransparentMesh: 1
+--- !u!1 &2010010001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2010010004}
+  - component: {fileID: 2010010003}
+  - component: {fileID: 2010010002}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2010010002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2010010001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.InputSystem::UnityEngine.InputSystem.UI.InputSystemUIInputModule
+  m_SendPointerHoverToParent: 1
+  m_MoveRepeatDelay: 0.5
+  m_MoveRepeatRate: 0.1
+  m_XRTrackingOrigin: {fileID: 0}
+  m_ActionsAsset: {fileID: -944628639613478452, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_PointAction: {fileID: -1654692200621890270, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_MoveAction: {fileID: -8784545083839296357, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_SubmitAction: {fileID: 392368643174621059, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_CancelAction: {fileID: 7727032971491509709, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_LeftClickAction: {fileID: 3001919216989983466, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_MiddleClickAction: {fileID: -2185481485913320682, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_RightClickAction: {fileID: -4090225696740746782, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_ScrollWheelAction: {fileID: 6240969308177333660, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_TrackedDevicePositionAction: {fileID: 6564999863303420839, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_TrackedDeviceOrientationAction: {fileID: 7970375526676320489, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_DeselectOnBackgroundClick: 1
+  m_PointerBehavior: 0
+  m_CursorLockBehavior: 0
+  m_ScrollDeltaPerTick: 6
+--- !u!114 &2010010003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2010010001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.EventSystems.EventSystem
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &2010010004
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2010010001}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2010020001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2010020003}
+  - component: {fileID: 2010020002}
+  m_Layer: 0
+  m_Name: ScoreSummarySceneRoot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2010020002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2010020001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3c5566f66dd4dbe9be9fca4ef8d6fb5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::ScoreSummaryHandler
+  mainMenuSceneName: MainMenu
+  nameInput: {fileID: 0}
+  categoryLineTexts: []
+  statusText: {fileID: 0}
+--- !u!4 &2010020003
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2010020001}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 498381497}
+  - {fileID: 1878376568}
+  - {fileID: 2010010004}
+  - {fileID: 2010020003}

--- a/LifeSimulation/Assets/Scenes/ScoreSummary.unity.meta
+++ b/LifeSimulation/Assets/Scenes/ScoreSummary.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ea532f2bb3e9473a8c3ef9d3b0d86ef5
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/LifeSimulation/Assets/Scenes/Simulation.unity
+++ b/LifeSimulation/Assets/Scenes/Simulation.unity
@@ -2739,6 +2739,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1503027205}
   - component: {fileID: 1503027204}
+  - component: {fileID: 1503027206}
   m_Layer: 0
   m_Name: SimulationManager
   m_TagString: Untagged
@@ -2759,6 +2760,23 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::SimulationManager
   currentSpeed: 1
+  simulationSceneHandler: {fileID: 1503027206}
+--- !u!114 &1503027206
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1503027203}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0d9a4d9e8c434ce0a4d31e4f4f32a08e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::SimulationSceneHandler
+  scoreSummarySceneName: ScoreSummary
+  logManager: {fileID: 0}
+  simulationLogger: {fileID: 0}
+  popTracker: {fileID: 0}
 --- !u!4 &1503027205
 Transform:
   m_ObjectHideFlags: 0
@@ -2831,7 +2849,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Button
+  m_text: Quit
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -3653,7 +3671,7 @@ GameObject:
   - component: {fileID: 2082769425}
   - component: {fileID: 2082769424}
   m_Layer: 5
-  m_Name: SpawnObstacleButton
+  m_Name: Quit
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -3723,14 +3741,14 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2144076348}
-        m_TargetAssemblyTypeName: WorldEditor, Assembly-CSharp
-        m_MethodName: SetSelection
-        m_Mode: 3
+      - m_Target: {fileID: 1503027206}
+        m_TargetAssemblyTypeName: SimulationSceneHandler, Assembly-CSharp
+        m_MethodName: Quit
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 4
+          m_IntArgument: 0
           m_FloatArgument: 0
           m_StringArgument: 
           m_BoolArgument: 0

--- a/LifeSimulation/Assets/Scenes/Simulation.unity
+++ b/LifeSimulation/Assets/Scenes/Simulation.unity
@@ -2740,6 +2740,9 @@ GameObject:
   - component: {fileID: 1503027205}
   - component: {fileID: 1503027204}
   - component: {fileID: 1503027206}
+  - component: {fileID: 1503027207}
+  - component: {fileID: 1503027208}
+  - component: {fileID: 1503027209}
   m_Layer: 0
   m_Name: SimulationManager
   m_TagString: Untagged
@@ -2774,9 +2777,55 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::SimulationSceneHandler
   scoreSummarySceneName: ScoreSummary
-  logManager: {fileID: 0}
-  simulationLogger: {fileID: 0}
-  popTracker: {fileID: 0}
+  logManager: {fileID: 1503027208}
+  simulationLogger: {fileID: 1503027207}
+  popTracker: {fileID: 1503027209}
+--- !u!114 &1503027207
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1503027203}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cc6065311941dd042bb22960b8cae40a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::SimulationLogger
+  filepath: 
+--- !u!114 &1503027208
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1503027203}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6c8d554e86183a34d81adadf3eab9d99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::LogManager
+  currentTick: 0
+  logInterval: 600
+  popTracker: {fileID: 1503027209}
+  simulationLogger: {fileID: 1503027207}
+--- !u!114 &1503027209
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1503027203}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0b0d23e0a57152d48be44993f8999654, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::PopTracker
+  ecosystemManager: {fileID: 2144076349}
+  simulationManager: {fileID: 1503027204}
+  plantPopulationKey: Plant
+  grazerPopulationKey: Grazer
+  predatorPopulationKey: Predator
 --- !u!4 &1503027205
 Transform:
   m_ObjectHideFlags: 0

--- a/LifeSimulation/Assets/Scripts/ConfigHandler.cs
+++ b/LifeSimulation/Assets/Scripts/ConfigHandler.cs
@@ -1,14 +1,14 @@
 // -----------------------------------------------------------------------------
 // Project:		EXTENDED LIFE SIMULATION CAPSTONE ASSIGNMENT
 // Item:		Configuration GUI
-// Requirement:
+// Requirement:	Configuration
 // Author:		Benjamin Jones
 // Date:		04/05/2026
 // Version:		0.0.0
 //
 // Description:
-//    JSON configuration import/export for the configuration scene; schema and
-//    data wiring to be added later.
+//    Configuration scene: import/export simulation settings as JSON, hold
+//    last imported text for downstream wiring, and navigate back to main menu.
 // -----------------------------------------------------------------------------
 
 using System.IO;

--- a/LifeSimulation/Assets/Scripts/Creatures/EcosystemManager.cs
+++ b/LifeSimulation/Assets/Scripts/Creatures/EcosystemManager.cs
@@ -34,6 +34,11 @@ public class EcosystemManager : MonoBehaviour
     private int _grazerCount;
     private int _predatorCount;
 
+    /// <summary> Current counts for logging / UI (SimulationManager.population is only updated by editor placement).</summary>
+    public int PlantCount => _plantCount;
+    public int GrazerCount => _grazerCount;
+    public int PredatorCount => _predatorCount;
+
     private float _replenishTimer;
 
     // ── Unity ─────────────────────────────────────────────────────────────────

--- a/LifeSimulation/Assets/Scripts/Leaderboard.meta
+++ b/LifeSimulation/Assets/Scripts/Leaderboard.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9c1d8b5d7d2648b39a4b89b6a517f5b2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/LifeSimulation/Assets/Scripts/Leaderboard/NakamaLeaderboardService.cs
+++ b/LifeSimulation/Assets/Scripts/Leaderboard/NakamaLeaderboardService.cs
@@ -7,10 +7,11 @@
 // Version:		0.0.0
 //
 // Description:
-//    Minimal Nakama HTTP integration for device authentication, leaderboard
-//    record writes, and top-record listing. Display names are stored only in
-//    record metadata (e.g. {"name":"..."}); leaderboards do not expose name as
-//    a separate queryable field.
+//    Nakama REST client for this project’s arcade leaderboards: authenticate
+//    (device id; optional disposable id per submit), POST scores with
+//    metadata JSON {"name":"..."} for display names, and GET top records.
+//    Used by ScoreSummary (writes) and Leaderboard scene (reads); ranks use
+//    numeric score only—names are not first-class leaderboard fields.
 // -----------------------------------------------------------------------------
 
 using System;
@@ -20,7 +21,7 @@ using System.Text;
 using UnityEngine;
 using UnityEngine.Networking;
 
-/// <summary> Provides minimal Nakama API calls used by leaderboard scenes. </summary>
+/// <summary> Nakama HTTP: auth, leaderboard write (flat REST body), list records. </summary>
 public class NakamaLeaderboardService : MonoBehaviour
 {
     public static NakamaLeaderboardService Instance;
@@ -78,13 +79,6 @@ public class NakamaLeaderboardService : MonoBehaviour
     private class LeaderboardNameMetadata
     {
         public string name;
-    }
-
-    /// <summary> Older client payloads used displayName; kept for read fallback. </summary>
-    [Serializable]
-    private class LegacyNameMetadata
-    {
-        public string displayName;
     }
 
     [Serializable]
@@ -277,12 +271,6 @@ public class NakamaLeaderboardService : MonoBehaviour
         }
     }
 
-    /// <summary> Provides a placeholder for future retry/backoff enhancements. </summary>
-    public void ConfigureRetryPolicySkeleton()
-    {
-        // Reserved for future implementation.
-    }
-
     private UnityWebRequest BuildJsonRequest(string url, string method, string body)
     {
         UnityWebRequest request = new UnityWebRequest(url, method)
@@ -346,12 +334,6 @@ public class NakamaLeaderboardService : MonoBehaviour
                 if (!string.IsNullOrWhiteSpace(byName.name))
                 {
                     return byName.name;
-                }
-
-                LegacyNameMetadata legacy = JsonUtility.FromJson<LegacyNameMetadata>(normalized);
-                if (!string.IsNullOrWhiteSpace(legacy.displayName))
-                {
-                    return legacy.displayName;
                 }
             }
             catch

--- a/LifeSimulation/Assets/Scripts/Leaderboard/NakamaLeaderboardService.cs
+++ b/LifeSimulation/Assets/Scripts/Leaderboard/NakamaLeaderboardService.cs
@@ -1,0 +1,380 @@
+// -----------------------------------------------------------------------------
+// Project:		EXTENDED LIFE SIMULATION CAPSTONE ASSIGNMENT
+// Item:		Nakama Leaderboard Service
+// Requirement:	Leaderboard
+// Author:		Benjamin Jones
+// Date:		04/14/2026
+// Version:		0.0.0
+//
+// Description:
+//    Minimal Nakama HTTP integration for device authentication, leaderboard
+//    record writes, and top-record listing. Display names are stored only in
+//    record metadata (e.g. {"name":"..."}); leaderboards do not expose name as
+//    a separate queryable field.
+// -----------------------------------------------------------------------------
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+using UnityEngine.Networking;
+
+/// <summary> Provides minimal Nakama API calls used by leaderboard scenes. </summary>
+public class NakamaLeaderboardService : MonoBehaviour
+{
+    public static NakamaLeaderboardService Instance;
+
+    [Header("Nakama Configuration")]
+    public string scheme = "http";
+    public string host = "172.200.210.208";
+    public int port = 7350;
+    public string serverKey = "defaultkey";
+    public int requestTimeoutSeconds = 10;
+    public bool useDisposableIdentityPerSubmit = true;
+
+    private string authToken;
+    private bool isAuthenticating;
+    private const string InsecureHttpHint = "Insecure HTTP blocked. Use HTTPS for Nakama or enable 'Allow downloads over HTTP' in Player Settings.";
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+    private static void Bootstrap()
+    {
+        if (Instance != null)
+        {
+            return;
+        }
+
+        var serviceObject = new GameObject("NakamaLeaderboardService");
+        serviceObject.AddComponent<NakamaLeaderboardService>();
+    }
+
+    [Serializable]
+    private class DeviceAuthRequest
+    {
+        public string id;
+    }
+
+    [Serializable]
+    private class DeviceAuthResponse
+    {
+        public string token;
+    }
+
+    /// <summary>
+    /// REST POST body for /v2/leaderboard/{id} is this object only — not wrapped in "record"
+    /// (see Nakama apigrpc.swagger.json: body schema LeaderboardRecordWrite).
+    /// </summary>
+    [Serializable]
+    private class LeaderboardRecordWriteBody
+    {
+        public string score;
+        public string subscore;
+        public string metadata;
+    }
+
+    /// <summary> Matches common Nakama metadata: {"name":"PlayerName"}. </summary>
+    [Serializable]
+    private class LeaderboardNameMetadata
+    {
+        public string name;
+    }
+
+    /// <summary> Older client payloads used displayName; kept for read fallback. </summary>
+    [Serializable]
+    private class LegacyNameMetadata
+    {
+        public string displayName;
+    }
+
+    [Serializable]
+    private class LeaderboardListResponse
+    {
+        public LeaderboardRecord[] records;
+    }
+
+    [Serializable]
+    public class LeaderboardRecord
+    {
+        public string owner_id;
+        public string score;
+        public string username;
+        public string metadata;
+        public long rank;
+    }
+
+    void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        scheme = NormalizeScheme(scheme);
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+    }
+
+    /// <summary> Ensures a device session token exists before leaderboard calls. </summary>
+    public IEnumerator EnsureAuthenticated(Action<bool> onComplete)
+    {
+        if (!string.IsNullOrEmpty(authToken))
+        {
+            onComplete?.Invoke(true);
+            yield break;
+        }
+
+        if (isAuthenticating)
+        {
+            yield return new WaitUntil(() => !isAuthenticating);
+            onComplete?.Invoke(!string.IsNullOrEmpty(authToken));
+            yield break;
+        }
+
+        isAuthenticating = true;
+        string deviceId;
+        if (useDisposableIdentityPerSubmit)
+        {
+            // Arcade mode: each submission run can use a disposable identity.
+            deviceId = Guid.NewGuid().ToString();
+        }
+        else
+        {
+            deviceId = PlayerPrefs.GetString("nakama_device_id", SystemInfo.deviceUniqueIdentifier);
+            if (deviceId == SystemInfo.unsupportedIdentifier || string.IsNullOrEmpty(deviceId))
+            {
+                deviceId = Guid.NewGuid().ToString();
+            }
+            PlayerPrefs.SetString("nakama_device_id", deviceId);
+        }
+
+        var request = new DeviceAuthRequest { id = deviceId };
+        string body = JsonUtility.ToJson(request);
+        string url = $"{scheme}://{host}:{port}/v2/account/authenticate/device?create=true";
+
+        using (UnityWebRequest webRequest = BuildJsonRequest(url, "POST", body))
+        {
+            webRequest.SetRequestHeader("Authorization", "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(serverKey + ":")));
+            UnityWebRequestAsyncOperation asyncOperation;
+            try
+            {
+                asyncOperation = webRequest.SendWebRequest();
+            }
+            catch (InvalidOperationException ex)
+            {
+                isAuthenticating = false;
+                Debug.LogError($"{InsecureHttpHint} Exception: {ex.Message}");
+                onComplete?.Invoke(false);
+                yield break;
+            }
+            yield return asyncOperation;
+
+            isAuthenticating = false;
+            if (webRequest.result != UnityWebRequest.Result.Success)
+            {
+                Debug.LogError("Nakama device auth failed: " + webRequest.error + " | " + webRequest.downloadHandler.text);
+                onComplete?.Invoke(false);
+                yield break;
+            }
+
+            DeviceAuthResponse response = JsonUtility.FromJson<DeviceAuthResponse>(webRequest.downloadHandler.text);
+            authToken = response != null ? response.token : null;
+            onComplete?.Invoke(!string.IsNullOrEmpty(authToken));
+        }
+    }
+
+    /// <summary> Writes a single leaderboard record with display name metadata. </summary>
+    public IEnumerator SubmitScore(string boardId, long score, string displayName, Action<bool> onComplete)
+    {
+        bool isReady = false;
+        yield return EnsureAuthenticated(ok => isReady = ok);
+        if (!isReady)
+        {
+            onComplete?.Invoke(false);
+            yield break;
+        }
+
+        string safeName = string.IsNullOrWhiteSpace(displayName) ? "Guest" : displayName.Trim();
+        string metadataJson = JsonUtility.ToJson(new LeaderboardNameMetadata { name = safeName });
+        var bodyObj = new LeaderboardRecordWriteBody
+        {
+            score = score.ToString(),
+            subscore = "0",
+            metadata = metadataJson
+        };
+
+        string url = $"{scheme}://{host}:{port}/v2/leaderboard/{boardId}";
+        using (UnityWebRequest webRequest = BuildJsonRequest(url, "POST", JsonUtility.ToJson(bodyObj)))
+        {
+            webRequest.SetRequestHeader("Authorization", "Bearer " + authToken);
+            UnityWebRequestAsyncOperation asyncOperation;
+            try
+            {
+                asyncOperation = webRequest.SendWebRequest();
+            }
+            catch (InvalidOperationException ex)
+            {
+                Debug.LogError($"{InsecureHttpHint} Exception: {ex.Message}");
+                onComplete?.Invoke(false);
+                yield break;
+            }
+            yield return asyncOperation;
+
+            if (webRequest.result != UnityWebRequest.Result.Success)
+            {
+                Debug.LogError("Nakama leaderboard submit failed: " + webRequest.error + " | " + webRequest.downloadHandler.text);
+                onComplete?.Invoke(false);
+                yield break;
+            }
+
+            onComplete?.Invoke(true);
+        }
+    }
+
+    /// <summary> Lists top records for a leaderboard board id. </summary>
+    public IEnumerator FetchTopRecords(string boardId, int limit, Action<List<LeaderboardRecord>> onComplete)
+    {
+        bool isReady = false;
+        yield return EnsureAuthenticated(ok => isReady = ok);
+        if (!isReady)
+        {
+            onComplete?.Invoke(new List<LeaderboardRecord>());
+            yield break;
+        }
+
+        string url = $"{scheme}://{host}:{port}/v2/leaderboard/{boardId}?limit={Mathf.Clamp(limit, 1, 100)}";
+        using (UnityWebRequest webRequest = BuildJsonRequest(url, "GET", null))
+        {
+            webRequest.SetRequestHeader("Authorization", "Bearer " + authToken);
+            UnityWebRequestAsyncOperation asyncOperation;
+            try
+            {
+                asyncOperation = webRequest.SendWebRequest();
+            }
+            catch (InvalidOperationException ex)
+            {
+                Debug.LogError($"{InsecureHttpHint} Exception: {ex.Message}");
+                onComplete?.Invoke(new List<LeaderboardRecord>());
+                yield break;
+            }
+            yield return asyncOperation;
+
+            if (webRequest.result != UnityWebRequest.Result.Success)
+            {
+                Debug.LogError("Nakama leaderboard fetch failed: " + webRequest.error + " | " + webRequest.downloadHandler.text);
+                onComplete?.Invoke(new List<LeaderboardRecord>());
+                yield break;
+            }
+
+            LeaderboardListResponse response = JsonUtility.FromJson<LeaderboardListResponse>(webRequest.downloadHandler.text);
+            int recordCount = response != null && response.records != null ? response.records.Length : 0;
+            Debug.Log($"Nakama leaderboard fetch success for '{boardId}'. Records: {recordCount}");
+            onComplete?.Invoke(response != null && response.records != null
+                ? new List<LeaderboardRecord>(response.records)
+                : new List<LeaderboardRecord>());
+        }
+    }
+
+    /// <summary> Provides a placeholder for future retry/backoff enhancements. </summary>
+    public void ConfigureRetryPolicySkeleton()
+    {
+        // Reserved for future implementation.
+    }
+
+    private UnityWebRequest BuildJsonRequest(string url, string method, string body)
+    {
+        UnityWebRequest request = new UnityWebRequest(url, method)
+        {
+            timeout = requestTimeoutSeconds
+        };
+
+        byte[] bodyBytes = string.IsNullOrEmpty(body) ? Array.Empty<byte>() : Encoding.UTF8.GetBytes(body);
+        request.uploadHandler = new UploadHandlerRaw(bodyBytes);
+        request.downloadHandler = new DownloadHandlerBuffer();
+        request.SetRequestHeader("Content-Type", "application/json");
+        request.SetRequestHeader("Accept", "application/json");
+        return request;
+    }
+
+    public void BeginNewSubmissionSession()
+    {
+        authToken = null;
+        isAuthenticating = false;
+    }
+
+    private string NormalizeScheme(string rawScheme)
+    {
+        if (string.IsNullOrWhiteSpace(rawScheme))
+        {
+            return "http";
+        }
+
+        string normalized = rawScheme.Trim().ToLowerInvariant();
+        if (normalized.EndsWith("://", StringComparison.Ordinal))
+        {
+            normalized = normalized.Substring(0, normalized.Length - 3);
+        }
+
+        if (normalized == "http" || normalized == "https")
+        {
+            return normalized;
+        }
+
+        return "http";
+    }
+
+    public static string ResolveDisplayName(LeaderboardRecord record)
+    {
+        if (record == null)
+        {
+            return "Guest";
+        }
+
+        if (!string.IsNullOrWhiteSpace(record.metadata))
+        {
+            try
+            {
+                string normalized = record.metadata.Trim();
+                if (normalized.StartsWith("\"") && normalized.EndsWith("\""))
+                {
+                    normalized = normalized.Substring(1, normalized.Length - 2).Replace("\\\"", "\"");
+                }
+
+                LeaderboardNameMetadata byName = JsonUtility.FromJson<LeaderboardNameMetadata>(normalized);
+                if (!string.IsNullOrWhiteSpace(byName.name))
+                {
+                    return byName.name;
+                }
+
+                LegacyNameMetadata legacy = JsonUtility.FromJson<LegacyNameMetadata>(normalized);
+                if (!string.IsNullOrWhiteSpace(legacy.displayName))
+                {
+                    return legacy.displayName;
+                }
+            }
+            catch
+            {
+                // Keep fallback behavior.
+            }
+        }
+
+        return "Guest";
+    }
+
+    public static string ResolveScore(LeaderboardRecord record)
+    {
+        if (record == null)
+        {
+            return "0";
+        }
+
+        if (long.TryParse(record.score, out long parsed))
+        {
+            return parsed.ToString();
+        }
+
+        return string.IsNullOrWhiteSpace(record.score) ? "0" : record.score;
+    }
+}

--- a/LifeSimulation/Assets/Scripts/Leaderboard/NakamaLeaderboardService.cs.meta
+++ b/LifeSimulation/Assets/Scripts/Leaderboard/NakamaLeaderboardService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 86b7f2cd4f0f4bc58b4f5de7f2f7e511
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/LifeSimulation/Assets/Scripts/Leaderboard/ScoreSummaryData.cs
+++ b/LifeSimulation/Assets/Scripts/Leaderboard/ScoreSummaryData.cs
@@ -1,0 +1,76 @@
+// -----------------------------------------------------------------------------
+// Project:		EXTENDED LIFE SIMULATION CAPSTONE ASSIGNMENT
+// Item:		Score Summary Data
+// Requirement:	Leaderboard
+// Author:		Benjamin Jones
+// Date:		04/14/2026
+// Version:		0.0.0
+//
+// Description:
+//    Stores transient score values between Simulation and ScoreSummary scenes.
+// -----------------------------------------------------------------------------
+
+using System;
+using UnityEngine;
+
+/// <summary> Defines leaderboard categories and board ids. </summary>
+public static class LeaderboardBoards
+{
+    public const string OverallScore = "overall_score";
+    public const string LongestSurvivalTime = "longest_survival_time";
+    public const string HighestStability = "highest_stability";
+    public const string HighestDiversity = "highest_diversity";
+    public const string HighestPopulationPeak = "highest_population_peak";
+
+    public static readonly string[] DisplayNames =
+    {
+        "Overall Score",
+        "Longest Survival Time",
+        "Highest Stability",
+        "Highest Diversity",
+        "Highest Population Peak"
+    };
+
+    public static readonly string[] BoardIds =
+    {
+        OverallScore,
+        LongestSurvivalTime,
+        HighestStability,
+        HighestDiversity,
+        HighestPopulationPeak
+    };
+}
+
+/// <summary> Stores numeric values for the five leaderboard categories. </summary>
+[Serializable]
+public class ScoreSummaryPayload
+{
+    public long overallScore;
+    public long longestSurvivalTime;
+    public long highestStability;
+    public long highestDiversity;
+    public long highestPopulationPeak;
+
+    public long[] ToOrderedArray()
+    {
+        return new[]
+        {
+            overallScore,
+            longestSurvivalTime,
+            highestStability,
+            highestDiversity,
+            highestPopulationPeak
+        };
+    }
+}
+
+/// <summary> Runtime container that carries summary values across scene loads. </summary>
+public static class ScoreSummaryData
+{
+    public static ScoreSummaryPayload CurrentRun = new ScoreSummaryPayload();
+
+    public static void SetCurrentRun(ScoreSummaryPayload payload)
+    {
+        CurrentRun = payload ?? new ScoreSummaryPayload();
+    }
+}

--- a/LifeSimulation/Assets/Scripts/Leaderboard/ScoreSummaryData.cs
+++ b/LifeSimulation/Assets/Scripts/Leaderboard/ScoreSummaryData.cs
@@ -7,7 +7,9 @@
 // Version:		0.0.0
 //
 // Description:
-//    Stores transient score values between Simulation and ScoreSummary scenes.
+//    Leaderboard board IDs and display labels for the five categories; static
+//    ScoreSummaryPayload handoff from Simulation (summary generation) to the
+//    ScoreSummary scene before Nakama submission.
 // -----------------------------------------------------------------------------
 
 using System;

--- a/LifeSimulation/Assets/Scripts/Leaderboard/ScoreSummaryData.cs.meta
+++ b/LifeSimulation/Assets/Scripts/Leaderboard/ScoreSummaryData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c2b8a3afaf7e4d7e829df6e36b8f9f20
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/LifeSimulation/Assets/Scripts/Leaderboard/ScoreSummaryHandler.cs
+++ b/LifeSimulation/Assets/Scripts/Leaderboard/ScoreSummaryHandler.cs
@@ -7,7 +7,10 @@
 // Version:		0.0.0
 //
 // Description:
-//    Handles score summary display and button actions for submit/discard flow.
+//    Post-simulation scene: shows the five Nakama category scores from
+//    ScoreSummaryData (filled when leaving Simulation), optional arcade name,
+//    Submit (writes each board via NakamaLeaderboardService) or Quit to main
+//    menu. Can build a minimal themed panel at runtime if the scene has no UI.
 // -----------------------------------------------------------------------------
 
 using System.Collections;
@@ -19,7 +22,7 @@ using UnityEngine.UI;
 using UnityEngine.EventSystems;
 using UnityEngine.InputSystem.UI;
 
-/// <summary> Handles ScoreSummary scene UI interactions. </summary>
+/// <summary> End-of-run summary UI: display metrics, submit to Nakama, or exit. </summary>
 public class ScoreSummaryHandler : MonoBehaviour
 {
     [Header("Scene Configuration")]
@@ -72,12 +75,6 @@ public class ScoreSummaryHandler : MonoBehaviour
     {
         Debug.Log("Score submission discarded by player.");
         SceneManager.LoadScene(mainMenuSceneName);
-    }
-
-    /// <summary> Placeholder for future detailed score model generation. </summary>
-    public void GenerateDetailedScoreBreakdown()
-    {
-        // Reserved for future implementation.
     }
 
     private void RenderSummary()

--- a/LifeSimulation/Assets/Scripts/Leaderboard/ScoreSummaryHandler.cs
+++ b/LifeSimulation/Assets/Scripts/Leaderboard/ScoreSummaryHandler.cs
@@ -1,0 +1,319 @@
+// -----------------------------------------------------------------------------
+// Project:		EXTENDED LIFE SIMULATION CAPSTONE ASSIGNMENT
+// Item:		Score Summary scene UI
+// Requirement:	Leaderboard
+// Author:		Benjamin Jones
+// Date:		04/14/2026
+// Version:		0.0.0
+//
+// Description:
+//    Handles score summary display and button actions for submit/discard flow.
+// -----------------------------------------------------------------------------
+
+using System.Collections;
+using TMPro;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using System.Linq;
+using UnityEngine.UI;
+using UnityEngine.EventSystems;
+using UnityEngine.InputSystem.UI;
+
+/// <summary> Handles ScoreSummary scene UI interactions. </summary>
+public class ScoreSummaryHandler : MonoBehaviour
+{
+    [Header("Scene Configuration")]
+    public string mainMenuSceneName = "MainMenu";
+
+    [Header("UI References")]
+    public TMP_InputField nameInput;
+    public TMP_Text[] categoryLineTexts;
+    public TMP_Text statusText;
+
+    private bool isSubmitting;
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+    private static void EnsureHandlerExists()
+    {
+        if (SceneManager.GetActiveScene().name != "ScoreSummary")
+        {
+            return;
+        }
+
+        if (FindFirstObjectByType<ScoreSummaryHandler>() != null)
+        {
+            return;
+        }
+
+        GameObject handlerObject = new GameObject("ScoreSummarySceneRoot");
+        handlerObject.AddComponent<ScoreSummaryHandler>();
+    }
+
+    void Start()
+    {
+        EnsureScoreSummaryLayout();
+        AutoAssignUiReferences();
+        RenderSummary();
+    }
+
+    /// <summary> Writes all category values to Nakama and returns to main menu. </summary>
+    public void SubmitAndQuit()
+    {
+        if (isSubmitting)
+        {
+            return;
+        }
+
+        StartCoroutine(SubmitAllScoresRoutine());
+    }
+
+    /// <summary> Discards score submission and returns to main menu. </summary>
+    public void QuitWithoutSubmitting()
+    {
+        Debug.Log("Score submission discarded by player.");
+        SceneManager.LoadScene(mainMenuSceneName);
+    }
+
+    /// <summary> Placeholder for future detailed score model generation. </summary>
+    public void GenerateDetailedScoreBreakdown()
+    {
+        // Reserved for future implementation.
+    }
+
+    private void RenderSummary()
+    {
+        ScoreSummaryPayload payload = ScoreSummaryData.CurrentRun ?? new ScoreSummaryPayload();
+        long[] values = payload.ToOrderedArray();
+
+        for (int i = 0; i < categoryLineTexts.Length && i < values.Length; i++)
+        {
+            if (categoryLineTexts[i] != null)
+            {
+                categoryLineTexts[i].text = $"{LeaderboardBoards.DisplayNames[i]} - {values[i]}";
+            }
+        }
+
+        if (statusText != null)
+        {
+            statusText.text = string.Empty;
+        }
+    }
+
+    private IEnumerator SubmitAllScoresRoutine()
+    {
+        isSubmitting = true;
+        SetStatus("Submitting scores...");
+
+        NakamaLeaderboardService service = NakamaLeaderboardService.Instance;
+        if (service == null)
+        {
+            SetStatus("Nakama service missing.");
+            isSubmitting = false;
+            yield break;
+        }
+
+        service.BeginNewSubmissionSession();
+
+        string displayName = nameInput != null && !string.IsNullOrWhiteSpace(nameInput.text)
+            ? nameInput.text.Trim()
+            : "Guest";
+
+        long[] values = (ScoreSummaryData.CurrentRun ?? new ScoreSummaryPayload()).ToOrderedArray();
+        bool allSucceeded = true;
+
+        for (int i = 0; i < LeaderboardBoards.BoardIds.Length && i < values.Length; i++)
+        {
+            bool succeeded = false;
+            yield return service.SubmitScore(LeaderboardBoards.BoardIds[i], values[i], displayName, ok => succeeded = ok);
+            allSucceeded &= succeeded;
+        }
+
+        if (!allSucceeded)
+        {
+            SetStatus("Submit failed. Check Nakama connection.");
+            isSubmitting = false;
+            yield break;
+        }
+
+        SetStatus("Submit complete.");
+        SceneManager.LoadScene(mainMenuSceneName);
+    }
+
+    private void SetStatus(string message)
+    {
+        if (statusText != null)
+        {
+            statusText.text = message;
+        }
+    }
+
+    private void AutoAssignUiReferences()
+    {
+        if (nameInput == null)
+        {
+            nameInput = FindFirstObjectByType<TMP_InputField>();
+        }
+
+        if (categoryLineTexts == null || categoryLineTexts.Length == 0)
+        {
+            TMP_Text[] allTexts = FindObjectsByType<TMP_Text>(FindObjectsInactive.Exclude, FindObjectsSortMode.None);
+            categoryLineTexts = allTexts
+                .Where(t => t != null && t.gameObject.name.StartsWith("CategoryLine"))
+                .OrderBy(t => t.gameObject.name)
+                .ToArray();
+        }
+    }
+
+    private void EnsureScoreSummaryLayout()
+    {
+        Canvas canvas = FindFirstObjectByType<Canvas>();
+        if (canvas == null)
+        {
+            GameObject canvasObject = new GameObject("Canvas", typeof(Canvas), typeof(CanvasScaler), typeof(GraphicRaycaster));
+            canvas = canvasObject.GetComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+
+            CanvasScaler scaler = canvasObject.GetComponent<CanvasScaler>();
+            // Mirrors Configuration scene CanvasScaler defaults.
+            scaler.uiScaleMode = CanvasScaler.ScaleMode.ConstantPixelSize;
+            scaler.referencePixelsPerUnit = 100f;
+            scaler.scaleFactor = 1f;
+            scaler.referenceResolution = new Vector2(800f, 600f);
+            scaler.screenMatchMode = CanvasScaler.ScreenMatchMode.MatchWidthOrHeight;
+            scaler.matchWidthOrHeight = 0f;
+            scaler.physicalUnit = CanvasScaler.Unit.Points;
+            scaler.fallbackScreenDPI = 96f;
+            scaler.defaultSpriteDPI = 96f;
+            scaler.dynamicPixelsPerUnit = 1f;
+        }
+
+        if (FindFirstObjectByType<EventSystem>() == null)
+        {
+            // Mirrors Configuration scene EventSystem module choice.
+            new GameObject("EventSystem", typeof(EventSystem), typeof(InputSystemUIInputModule));
+        }
+
+        Transform panel = canvas.transform.Find("ScoreSummaryPanel");
+        if (panel == null)
+        {
+            GameObject panelObject = new GameObject("ScoreSummaryPanel", typeof(RectTransform), typeof(Image));
+            panelObject.transform.SetParent(canvas.transform, false);
+            RectTransform createdPanelRect = panelObject.GetComponent<RectTransform>();
+            createdPanelRect.anchorMin = new Vector2(0.5f, 0.5f);
+            createdPanelRect.anchorMax = new Vector2(0.5f, 0.5f);
+            createdPanelRect.pivot = new Vector2(0.5f, 0.5f);
+            createdPanelRect.sizeDelta = new Vector2(1100f, 760f);
+            createdPanelRect.anchoredPosition = Vector2.zero;
+            panelObject.GetComponent<Image>().color = new Color32(20, 34, 45, 235);
+            panel = panelObject.transform;
+        }
+        RectTransform panelRect = panel.GetComponent<RectTransform>();
+        panelRect.anchorMin = new Vector2(0.5f, 0.5f);
+        panelRect.anchorMax = new Vector2(0.5f, 0.5f);
+        panelRect.pivot = new Vector2(0.5f, 0.5f);
+        panelRect.anchoredPosition = Vector2.zero;
+        panelRect.sizeDelta = new Vector2(900f, 760f);
+
+        // Clear pre-existing mixed content so we keep one clean functional copy.
+        foreach (Transform child in panel)
+        {
+            Destroy(child.gameObject);
+        }
+
+        CreateLabel(panel, "Title", "Score Summary", new Vector2(0f, 300f), 52, TextAlignmentOptions.Center, Color.white);
+
+        for (int i = 0; i < LeaderboardBoards.DisplayNames.Length; i++)
+        {
+            float y = 180f - (i * 75f);
+            CreateLabel(panel, $"CategoryLine{i + 1}", $"{LeaderboardBoards.DisplayNames[i]} - 0", new Vector2(0f, y), 34, TextAlignmentOptions.Center, Color.white);
+        }
+
+        nameInput = CreateNameInput(panel, new Vector2(0f, -230f));
+        CreateButton(panel, "SubmitButton", "Submit", new Vector2(-140f, -315f), SubmitAndQuit);
+        CreateButton(panel, "QuitButton", "Quit", new Vector2(140f, -315f), QuitWithoutSubmitting);
+        statusText = CreateLabel(panel, "StatusText", string.Empty, new Vector2(0f, -270f), 24, TextAlignmentOptions.Center, Color.white);
+    }
+
+    private TMP_Text CreateLabel(Transform parent, string objectName, string text, Vector2 position, float fontSize, TextAlignmentOptions alignment, Color color)
+    {
+        GameObject labelObject = new GameObject(objectName, typeof(RectTransform), typeof(TextMeshProUGUI));
+        labelObject.transform.SetParent(parent, false);
+        RectTransform rect = labelObject.GetComponent<RectTransform>();
+        rect.anchorMin = new Vector2(0.5f, 0.5f);
+        rect.anchorMax = new Vector2(0.5f, 0.5f);
+        rect.pivot = new Vector2(0.5f, 0.5f);
+        rect.sizeDelta = new Vector2(900f, 60f);
+        rect.anchoredPosition = position;
+
+        TextMeshProUGUI label = labelObject.GetComponent<TextMeshProUGUI>();
+        label.text = text;
+        label.fontSize = fontSize;
+        label.alignment = alignment;
+        label.color = color;
+        return label;
+    }
+
+    private TMP_InputField CreateNameInput(Transform parent, Vector2 position)
+    {
+        GameObject root = new GameObject("NameInput", typeof(RectTransform), typeof(Image), typeof(TMP_InputField));
+        root.transform.SetParent(parent, false);
+        RectTransform rootRect = root.GetComponent<RectTransform>();
+        rootRect.anchorMin = new Vector2(0.5f, 0.5f);
+        rootRect.anchorMax = new Vector2(0.5f, 0.5f);
+        rootRect.pivot = new Vector2(0.5f, 0.5f);
+        rootRect.sizeDelta = new Vector2(580f, 64f);
+        rootRect.anchoredPosition = position;
+        root.GetComponent<Image>().color = new Color32(245, 245, 245, 255);
+
+        GameObject textArea = new GameObject("Text Area", typeof(RectTransform));
+        textArea.transform.SetParent(root.transform, false);
+        RectTransform areaRect = textArea.GetComponent<RectTransform>();
+        areaRect.anchorMin = new Vector2(0f, 0f);
+        areaRect.anchorMax = new Vector2(1f, 1f);
+        areaRect.offsetMin = new Vector2(12f, 8f);
+        areaRect.offsetMax = new Vector2(-12f, -8f);
+
+        TextMeshProUGUI textComponent = CreateLabel(textArea.transform, "Text", string.Empty, Vector2.zero, 28, TextAlignmentOptions.Left, new Color32(40, 40, 40, 255)) as TextMeshProUGUI;
+        RectTransform textRect = textComponent.GetComponent<RectTransform>();
+        textRect.anchorMin = new Vector2(0f, 0f);
+        textRect.anchorMax = new Vector2(1f, 1f);
+        textRect.offsetMin = Vector2.zero;
+        textRect.offsetMax = Vector2.zero;
+
+        TextMeshProUGUI placeholder = CreateLabel(textArea.transform, "Placeholder", "Enter Name", Vector2.zero, 28, TextAlignmentOptions.Left, new Color32(120, 120, 120, 255)) as TextMeshProUGUI;
+        RectTransform placeholderRect = placeholder.GetComponent<RectTransform>();
+        placeholderRect.anchorMin = new Vector2(0f, 0f);
+        placeholderRect.anchorMax = new Vector2(1f, 1f);
+        placeholderRect.offsetMin = Vector2.zero;
+        placeholderRect.offsetMax = Vector2.zero;
+
+        TMP_InputField inputField = root.GetComponent<TMP_InputField>();
+        inputField.textComponent = textComponent;
+        inputField.placeholder = placeholder;
+        inputField.characterLimit = 20;
+        return inputField;
+    }
+
+    private void CreateButton(Transform parent, string objectName, string labelText, Vector2 position, UnityEngine.Events.UnityAction onClick)
+    {
+        GameObject buttonObject = new GameObject(objectName, typeof(RectTransform), typeof(Image), typeof(Button));
+        buttonObject.transform.SetParent(parent, false);
+        RectTransform buttonRect = buttonObject.GetComponent<RectTransform>();
+        buttonRect.anchorMin = new Vector2(0.5f, 0.5f);
+        buttonRect.anchorMax = new Vector2(0.5f, 0.5f);
+        buttonRect.pivot = new Vector2(0.5f, 0.5f);
+        buttonRect.sizeDelta = new Vector2(260f, 68f);
+        buttonRect.anchoredPosition = position;
+
+        buttonObject.GetComponent<Image>().color = new Color32(27, 182, 176, 255);
+        Button button = buttonObject.GetComponent<Button>();
+        button.onClick.AddListener(onClick);
+
+        TMP_Text label = CreateLabel(buttonObject.transform, "Text (TMP)", labelText, Vector2.zero, 30, TextAlignmentOptions.Center, new Color32(45, 45, 45, 255));
+        RectTransform labelRect = label.GetComponent<RectTransform>();
+        labelRect.anchorMin = Vector2.zero;
+        labelRect.anchorMax = Vector2.one;
+        labelRect.offsetMin = Vector2.zero;
+        labelRect.offsetMax = Vector2.zero;
+    }
+}

--- a/LifeSimulation/Assets/Scripts/Leaderboard/ScoreSummaryHandler.cs.meta
+++ b/LifeSimulation/Assets/Scripts/Leaderboard/ScoreSummaryHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e3c5566f66dd4dbe9be9fca4ef8d6fb5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/LifeSimulation/Assets/Scripts/LeaderboardSceneHandler.cs
+++ b/LifeSimulation/Assets/Scripts/LeaderboardSceneHandler.cs
@@ -1,13 +1,14 @@
 // -----------------------------------------------------------------------------
 // Project:		EXTENDED LIFE SIMULATION CAPSTONE ASSIGNMENT
 // Item:		Leaderboard scene UI
-// Requirement:
+// Requirement:	Leaderboard
 // Author:		Benjamin Jones
 // Date:		04/05/2026
 // Version:		0.0.0
 //
 // Description:
-//    Scene navigation for the leaderboard UI (e.g. return to main menu).
+//    Leaderboard scene: category dropdown selects Nakama board IDs; loads top
+//    rows and binds Name/Score TMP fields. Back navigates to main menu.
 // -----------------------------------------------------------------------------
 
 using UnityEngine;
@@ -18,7 +19,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine.UI;
 
-/// <summary> handles leaderboard scene UI actions </summary>
+/// <summary> Leaderboard UI: fetch Nakama records per category, fill rows. </summary>
 public class LeaderboardSceneHandler : MonoBehaviour
 {
     [Header("Scene Configuration")]
@@ -49,12 +50,6 @@ public class LeaderboardSceneHandler : MonoBehaviour
     public void OnCategoryChanged()
     {
         StartCoroutine(RefreshSelectedCategoryRoutine());
-    }
-
-    /// <summary> Placeholder for future leaderboard pagination support. </summary>
-    public void LoadNextLeaderboardPage()
-    {
-        // Reserved for future implementation.
     }
 
     private void InitializeDropdown()

--- a/LifeSimulation/Assets/Scripts/LeaderboardSceneHandler.cs
+++ b/LifeSimulation/Assets/Scripts/LeaderboardSceneHandler.cs
@@ -12,6 +12,11 @@
 
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using TMPro;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine.UI;
 
 /// <summary> handles leaderboard scene UI actions </summary>
 public class LeaderboardSceneHandler : MonoBehaviour
@@ -19,10 +24,195 @@ public class LeaderboardSceneHandler : MonoBehaviour
     [Header("Scene Configuration")]
     public string mainMenuSceneName = "MainMenu";
 
+    [Header("Leaderboard UI")]
+    public TMP_Dropdown categoryDropdown;
+    public TMP_Text[] nameRowTexts;
+    public TMP_Text[] scoreRowTexts;
+    public TMP_Text statusText;
+    public RectTransform[] rowContainers;
+
+    void Start()
+    {
+        AutoAssignUiReferences();
+        InitializeDropdown();
+        StartCoroutine(RefreshSelectedCategoryRoutine());
+    }
+
     /// <summary> returns to main menu scene </summary>
     public void BackToMainMenu()
     {
         Debug.Log("Back To Main Menu Selected");
         SceneManager.LoadScene(mainMenuSceneName);
+    }
+
+    /// <summary> Handles category dropdown selection changes. </summary>
+    public void OnCategoryChanged()
+    {
+        StartCoroutine(RefreshSelectedCategoryRoutine());
+    }
+
+    /// <summary> Placeholder for future leaderboard pagination support. </summary>
+    public void LoadNextLeaderboardPage()
+    {
+        // Reserved for future implementation.
+    }
+
+    private void InitializeDropdown()
+    {
+        if (categoryDropdown == null)
+        {
+            return;
+        }
+
+        categoryDropdown.ClearOptions();
+        categoryDropdown.AddOptions(new List<string>(LeaderboardBoards.DisplayNames));
+        categoryDropdown.onValueChanged.RemoveAllListeners();
+        categoryDropdown.onValueChanged.AddListener(_ => OnCategoryChanged());
+        categoryDropdown.value = 0;
+        categoryDropdown.RefreshShownValue();
+    }
+
+    private void AutoAssignUiReferences()
+    {
+        if (categoryDropdown == null)
+        {
+            categoryDropdown = FindFirstObjectByType<TMP_Dropdown>();
+        }
+
+        if ((nameRowTexts == null || nameRowTexts.Length == 0) || (scoreRowTexts == null || scoreRowTexts.Length == 0))
+        {
+            AutoAssignRowsFromContainers();
+        }
+    }
+
+    private IEnumerator RefreshSelectedCategoryRoutine()
+    {
+        SetStatus("Loading...");
+        ClearRows();
+
+        NakamaLeaderboardService service = NakamaLeaderboardService.Instance;
+        if (service == null)
+        {
+            SetStatus("Nakama service missing.");
+            yield break;
+        }
+
+        int index = categoryDropdown != null ? Mathf.Clamp(categoryDropdown.value, 0, LeaderboardBoards.BoardIds.Length - 1) : 0;
+        string boardId = LeaderboardBoards.BoardIds[index];
+
+        List<NakamaLeaderboardService.LeaderboardRecord> records = null;
+        yield return service.FetchTopRecords(boardId, Mathf.Min(nameRowTexts.Length, scoreRowTexts.Length), result => records = result);
+        records = records ?? new List<NakamaLeaderboardService.LeaderboardRecord>();
+
+        for (int i = 0; i < nameRowTexts.Length && i < scoreRowTexts.Length; i++)
+        {
+            if (i >= records.Count)
+            {
+                break;
+            }
+
+            NakamaLeaderboardService.LeaderboardRecord record = records[i];
+            nameRowTexts[i].text = NakamaLeaderboardService.ResolveDisplayName(record);
+            scoreRowTexts[i].text = NakamaLeaderboardService.ResolveScore(record);
+        }
+
+        SetStatus(records.Count > 0 ? string.Empty : "No records yet.");
+    }
+
+    private void ClearRows()
+    {
+        for (int i = 0; i < nameRowTexts.Length; i++)
+        {
+            if (nameRowTexts[i] != null)
+            {
+                nameRowTexts[i].text = "-";
+            }
+        }
+
+        for (int i = 0; i < scoreRowTexts.Length; i++)
+        {
+            if (scoreRowTexts[i] != null)
+            {
+                scoreRowTexts[i].text = "-";
+            }
+        }
+    }
+
+    private void SetStatus(string message)
+    {
+        if (statusText != null)
+        {
+            statusText.text = message;
+        }
+    }
+
+    private void AutoAssignRowsFromContainers()
+    {
+        if (rowContainers == null || rowContainers.Length == 0)
+        {
+            List<RectTransform> foundRows = new List<RectTransform>();
+            for (int i = 1; i <= 20; i++)
+            {
+                GameObject row = GameObject.Find("Row" + i);
+                if (row != null)
+                {
+                    RectTransform rect = row.GetComponent<RectTransform>();
+                    if (rect != null)
+                    {
+                        foundRows.Add(rect);
+                    }
+                }
+            }
+
+            if (foundRows.Count == 0)
+            {
+                // Fallback for scenes where rows are grouped under a single RowContainer object.
+                GameObject container = GameObject.Find("RowContainer");
+                if (container != null)
+                {
+                    foreach (RectTransform child in container.GetComponentsInChildren<RectTransform>(true))
+                    {
+                        if (child != null && child.name.StartsWith("Row"))
+                        {
+                            foundRows.Add(child);
+                        }
+                    }
+                }
+            }
+
+            rowContainers = foundRows.ToArray();
+        }
+
+        List<TMP_Text> names = new List<TMP_Text>();
+        List<TMP_Text> scores = new List<TMP_Text>();
+
+        foreach (RectTransform row in rowContainers)
+        {
+            if (row == null)
+            {
+                continue;
+            }
+
+            TMP_Text[] texts = row.GetComponentsInChildren<TMP_Text>(true);
+            TMP_Text name = texts.FirstOrDefault(t => t.gameObject.name == "Name");
+            TMP_Text score = texts.FirstOrDefault(t => t.gameObject.name == "Score");
+
+            if (name != null && score != null)
+            {
+                names.Add(name);
+                scores.Add(score);
+            }
+        }
+
+        if (names.Count == 0 || scores.Count == 0)
+        {
+            // Final fallback: collect all row texts named Name/Score and skip header labels.
+            TMP_Text[] allTexts = FindObjectsByType<TMP_Text>(FindObjectsInactive.Exclude, FindObjectsSortMode.None);
+            names = allTexts.Where(t => t != null && t.gameObject.name == "Name").Skip(1).ToList();
+            scores = allTexts.Where(t => t != null && t.gameObject.name == "Score").Skip(1).ToList();
+        }
+
+        nameRowTexts = names.ToArray();
+        scoreRowTexts = scores.ToArray();
     }
 }

--- a/LifeSimulation/Assets/Scripts/Logging/LogEntry.cs
+++ b/LifeSimulation/Assets/Scripts/Logging/LogEntry.cs
@@ -37,4 +37,7 @@ public class LogEntry
         this.tick = tick;
         this.data = data;
     }
+
+    /// <summary>Required for JsonUtility.FromJson when re-reading log lines.</summary>
+    public LogEntry() { }
 }

--- a/LifeSimulation/Assets/Scripts/Logging/LogManager.cs
+++ b/LifeSimulation/Assets/Scripts/Logging/LogManager.cs
@@ -25,16 +25,18 @@ public class LogManager : MonoBehaviour
 
     public PopTracker popTracker;
     public SimulationLogger simulationLogger;
+    public MapGenerator2D mapGenerator;
+    private bool hasLoggedInitialSnapshot;
 
     /// <summary>
     /// When simualtion starts --> log inital population
     /// </summary>
     void Start()
     {
-        // Capture initial population at start of simulation
-        PopSnapshot snapshot = popTracker.GetSnapshot(currentTick);
-
-        simulationLogger.SaveToFile(snapshot);
+        if (mapGenerator == null)
+        {
+            mapGenerator = FindFirstObjectByType<MapGenerator2D>();
+        }
     }
 
     /// <summary>
@@ -53,6 +55,19 @@ public class LogManager : MonoBehaviour
     /// </summary>
     void Update()
     {
+        if (!IsSimulationStarted())
+        {
+            return;
+        }
+
+        if (!hasLoggedInitialSnapshot)
+        {
+            // First logged tick is now tied to map generation (true simulation start).
+            PopSnapshot startSnapshot = popTracker.GetSnapshot(currentTick);
+            simulationLogger.SaveToFile(startSnapshot);
+            hasLoggedInitialSnapshot = true;
+        }
+
         currentTick++;
 
         if (currentTick % logInterval == 0)
@@ -112,6 +127,11 @@ public class LogManager : MonoBehaviour
             }
 
         }
+    }
+
+    private bool IsSimulationStarted()
+    {
+        return mapGenerator != null && mapGenerator.HasSimulationStarted && mapGenerator.IsMapReady;
     }
 
 }

--- a/LifeSimulation/Assets/Scripts/Logging/PopSnapshot.cs
+++ b/LifeSimulation/Assets/Scripts/Logging/PopSnapshot.cs
@@ -42,4 +42,7 @@ public class PopSnapshot
         predatorCount = predators;
         totalPop = plants + grazers + predators;
     }
+
+    /// <summary>Required for JsonUtility.FromJson in SummaryGenerator.</summary>
+    public PopSnapshot() { }
 }

--- a/LifeSimulation/Assets/Scripts/Logging/PopTracker.cs
+++ b/LifeSimulation/Assets/Scripts/Logging/PopTracker.cs
@@ -19,6 +19,13 @@ using UnityEngine;
 /// </summary>
 public class PopTracker : MonoBehaviour
 {
+    [Header("Optional Sources")]
+    public SimulationManager simulationManager;
+
+    public string plantPopulationKey = "Plant";
+    public string grazerPopulationKey = "Grazer";
+    public string predatorPopulationKey = "Predator";
+
     /// <summary>
     /// Generates population snapshot for current tick
     /// </summary>
@@ -26,11 +33,33 @@ public class PopTracker : MonoBehaviour
     /// <returns>PopSnapshot containing population counts</returns>
     public PopSnapshot GetSnapshot(int tick)
     {
-        //Temporary placeholder values for independent prototype
-        int plants = Random.Range(50, 150);
-        int grazers = Random.Range(10, 50);
-        int predators = Random.Range(5, 20);
+        int plants = TryGetPopulation(plantPopulationKey);
+        int grazers = TryGetPopulation(grazerPopulationKey);
+        int predators = TryGetPopulation(predatorPopulationKey);
+
+        if (plants == 0 && grazers == 0 && predators == 0)
+        {
+            // Temporary fallback when sim dictionary keys are not configured yet.
+            plants = Random.Range(50, 150);
+            grazers = Random.Range(10, 50);
+            predators = Random.Range(5, 20);
+        }
 
         return new PopSnapshot(tick, plants, grazers, predators);
+    }
+
+    private int TryGetPopulation(string key)
+    {
+        if (simulationManager == null || string.IsNullOrWhiteSpace(key))
+        {
+            return 0;
+        }
+
+        if (simulationManager.population == null || !simulationManager.population.TryGetValue(key, out int count))
+        {
+            return 0;
+        }
+
+        return Mathf.Max(0, count);
     }
 }

--- a/LifeSimulation/Assets/Scripts/Logging/PopTracker.cs
+++ b/LifeSimulation/Assets/Scripts/Logging/PopTracker.cs
@@ -20,6 +20,10 @@ using UnityEngine;
 public class PopTracker : MonoBehaviour
 {
     [Header("Optional Sources")]
+    [Tooltip("Authoritative runtime counts (spawn/death). Prefer this over SimulationManager.population.")]
+    public EcosystemManager ecosystemManager;
+
+    [Tooltip("Only updated when placing via WorldEditor; used if EcosystemManager is missing.")]
     public SimulationManager simulationManager;
 
     public string plantPopulationKey = "Plant";
@@ -33,16 +37,22 @@ public class PopTracker : MonoBehaviour
     /// <returns>PopSnapshot containing population counts</returns>
     public PopSnapshot GetSnapshot(int tick)
     {
-        int plants = TryGetPopulation(plantPopulationKey);
-        int grazers = TryGetPopulation(grazerPopulationKey);
-        int predators = TryGetPopulation(predatorPopulationKey);
+        int plants;
+        int grazers;
+        int predators;
 
-        if (plants == 0 && grazers == 0 && predators == 0)
+        EcosystemManager eco = ecosystemManager != null ? ecosystemManager : EcosystemManager.Instance;
+        if (eco != null)
         {
-            // Temporary fallback when sim dictionary keys are not configured yet.
-            plants = Random.Range(50, 150);
-            grazers = Random.Range(10, 50);
-            predators = Random.Range(5, 20);
+            plants = eco.PlantCount;
+            grazers = eco.GrazerCount;
+            predators = eco.PredatorCount;
+        }
+        else
+        {
+            plants = TryGetPopulation(plantPopulationKey);
+            grazers = TryGetPopulation(grazerPopulationKey);
+            predators = TryGetPopulation(predatorPopulationKey);
         }
 
         return new PopSnapshot(tick, plants, grazers, predators);

--- a/LifeSimulation/Assets/Scripts/Logging/SimulationLogger.cs
+++ b/LifeSimulation/Assets/Scripts/Logging/SimulationLogger.cs
@@ -24,20 +24,13 @@ public class SimulationLogger : MonoBehaviour
     public string filepath;
 
     /// <summary>
-    /// Generates timestamped file to store the current simulation run.
-    /// Initializes logging on simulation start. 
+    /// Reserves log path before any LogManager.Start snapshot so the first line is never written to a null path.
     /// </summary>
-    void Start()
+    void Awake()
     {
         string timestamp = System.DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss");
-
-        // Generate File Path
         filepath = Application.persistentDataPath + "/population_log_" + timestamp + ".json";
-
-        // Create file with header
         File.WriteAllText(filepath, "");
-
-        // Print file location to Unity Console
         Debug.Log("Log file created at: " + filepath);
     }
 

--- a/LifeSimulation/Assets/Scripts/Logging/SummaryGenerator.cs
+++ b/LifeSimulation/Assets/Scripts/Logging/SummaryGenerator.cs
@@ -3,62 +3,96 @@ using UnityEngine;
 
 public class SummaryGenerator
 {
-    public static void GenerateSummary(string filepath)
+    public static ScoreSummaryPayload GenerateSummaryPayload(string filepath)
     {
+        if (string.IsNullOrEmpty(filepath) || !File.Exists(filepath))
+        {
+            return new ScoreSummaryPayload();
+        }
+
         string[] lines = File.ReadAllLines(filepath);
 
         int startPlants = 0, startGrazers = 0, startPredators = 0;
         int endPlants = 0, endGrazers = 0, endPredators = 0;
-
         int maxPlants = 0, maxGrazers = 0, maxPredators = 0;
-
         int duration = 0;
 
         bool firstSnapshot = true;
+        int stableTicks = 0;
+        int lastTotal = -1;
 
         foreach (string line in lines)
         {
-            LogEntry entry = JsonUtility.FromJson<LogEntry>(line);
-
-            if (entry.entryType == "Snapshot")
+            if (string.IsNullOrWhiteSpace(line))
             {
-                PopSnapshot snapshot = JsonUtility.FromJson<PopSnapshot>(entry.data);
-
-                // First snapshot = starting population
-                if (firstSnapshot)
-                {
-                    startPlants = snapshot.plantCount;
-                    startGrazers = snapshot.grazerCount;
-                    startPredators = snapshot.predatorCount;
-                    firstSnapshot = false;
-                }
-
-                // Always update ending values
-                endPlants = snapshot.plantCount;
-                endGrazers = snapshot.grazerCount;
-                endPredators = snapshot.predatorCount;
-
-                // Track max values
-                maxPlants = Mathf.Max(maxPlants, snapshot.plantCount);
-                maxGrazers = Mathf.Max(maxGrazers, snapshot.grazerCount);
-                maxPredators = Mathf.Max(maxPredators, snapshot.predatorCount);
-
-                // Track duration
-                duration = snapshot.tick;
+                continue;
             }
+
+            LogEntry entry = JsonUtility.FromJson<LogEntry>(line);
+            if (entry == null || entry.entryType != "Snapshot")
+            {
+                continue;
+            }
+
+            PopSnapshot snapshot = JsonUtility.FromJson<PopSnapshot>(entry.data);
+            if (snapshot == null)
+            {
+                continue;
+            }
+
+            if (firstSnapshot)
+            {
+                startPlants = snapshot.plantCount;
+                startGrazers = snapshot.grazerCount;
+                startPredators = snapshot.predatorCount;
+                firstSnapshot = false;
+            }
+
+            endPlants = snapshot.plantCount;
+            endGrazers = snapshot.grazerCount;
+            endPredators = snapshot.predatorCount;
+
+            maxPlants = Mathf.Max(maxPlants, snapshot.plantCount);
+            maxGrazers = Mathf.Max(maxGrazers, snapshot.grazerCount);
+            maxPredators = Mathf.Max(maxPredators, snapshot.predatorCount);
+            duration = snapshot.tick;
+
+            if (lastTotal >= 0 && Mathf.Abs(snapshot.totalPop - lastTotal) <= 5)
+            {
+                stableTicks++;
+            }
+            lastTotal = snapshot.totalPop;
         }
+
+        int peakPopulation = maxPlants + maxGrazers + maxPredators;
+        int diversity = 0;
+        diversity += endPlants > 0 ? 1 : 0;
+        diversity += endGrazers > 0 ? 1 : 0;
+        diversity += endPredators > 0 ? 1 : 0;
+
+        // Minimal placeholder formula for current milestone.
+        long overall = duration + peakPopulation + (stableTicks * 2) + (diversity * 100);
+
+        return new ScoreSummaryPayload
+        {
+            overallScore = overall,
+            longestSurvivalTime = duration,
+            highestStability = stableTicks,
+            highestDiversity = diversity,
+            highestPopulationPeak = peakPopulation
+        };
+    }
+
+    public static void GenerateSummary(string filepath)
+    {
+        ScoreSummaryPayload payload = GenerateSummaryPayload(filepath);
 
         // Print summary (for now)
         Debug.Log("=== Simulation Summary ===");
-        Debug.Log("Duration: " + duration + " ticks");
-
-        Debug.Log("Starting Population:");
-        Debug.Log("Plants: " + startPlants + ", Grazers: " + startGrazers + ", Predators: " + startPredators);
-
-        Debug.Log("Maximum Population:");
-        Debug.Log("Plants: " + maxPlants + ", Grazers: " + maxGrazers + ", Predators: " + maxPredators);
-
-        Debug.Log("Ending Population:");
-        Debug.Log("Plants: " + endPlants + ", Grazers: " + endGrazers + ", Predators: " + endPredators);
+        Debug.Log("Overall Score: " + payload.overallScore);
+        Debug.Log("Longest Survival Time: " + payload.longestSurvivalTime);
+        Debug.Log("Highest Stability: " + payload.highestStability);
+        Debug.Log("Highest Diversity: " + payload.highestDiversity);
+        Debug.Log("Highest Population Peak: " + payload.highestPopulationPeak);
     }
 }

--- a/LifeSimulation/Assets/Scripts/MapGenerator2D.cs
+++ b/LifeSimulation/Assets/Scripts/MapGenerator2D.cs
@@ -39,12 +39,20 @@ public class MapGenerator2D : MonoBehaviour
     // random valid spawn positions without landing inside an obstacle.
     private List<Vector3> _openTiles = new List<Vector3>();
 
+    /// <summary> True only after <see cref="GenerateMap"/> has finished (tiles + obstacles). Used to block editor spawns before the first generate.</summary>
+    public bool IsMapReady { get; private set; }
+    /// <summary> True once the user has generated at least one map in this scene session.</summary>
+    public bool HasSimulationStarted { get; private set; }
+
     /// <summary> Executes map generation logic then spawns initial entities </summary>
     /// <param name="seed"> String used to seed the RNG </param>
     /// <param name="width"> Width of map in tiles </param>
     /// <param name="height"> Height of map in tiles </param>
     public void GenerateMap(string seed, int width, int height)
     {
+        IsMapReady = false;
+        HasSimulationStarted = false;
+
         // Wipe existing data to prepare for new generation
         squareTilemap.ClearAllTiles();
         _openTiles.Clear();
@@ -83,10 +91,26 @@ public class MapGenerator2D : MonoBehaviour
         if (obstaclePrefab != null)
             SpawnObstacles();
 
+        IsMapReady = true;
+        HasSimulationStarted = true;
+
         // ── Initial entity spawning ───────────────────────────────────────────
         // Use Invoke so EcosystemManager and BoundaryManager have had a frame
         // to initialise before we ask them to spawn anything.
         Invoke(nameof(SpawnInitialEntities), 0.1f);
+    }
+
+    /// <summary> Random walkable tile center (excludes obstacle cells). Use for UI button spawns.</summary>
+    public bool TryGetRandomOpenTileWorldPosition(out Vector3 worldCenter)
+    {
+        worldCenter = default;
+        if (!IsMapReady || _openTiles.Count == 0)
+        {
+            return false;
+        }
+
+        worldCenter = _openTiles[UnityEngine.Random.Range(0, _openTiles.Count)];
+        return true;
     }
 
     // ── Obstacle Spawning ─────────────────────────────────────────────────────

--- a/LifeSimulation/Assets/Scripts/SimulationManager.cs
+++ b/LifeSimulation/Assets/Scripts/SimulationManager.cs
@@ -12,7 +12,6 @@
 
 using UnityEngine;
 using System.Collections.Generic;
-using UnityEngine.SceneManagement;
 
 public class SimulationManager : MonoBehaviour
 {
@@ -26,6 +25,7 @@ public class SimulationManager : MonoBehaviour
     [Header("Simulation State")]
     public float currentSpeed = 1.0f;
     private bool isHalted = false;
+    public SimulationSceneHandler simulationSceneHandler;
 
     //
     void Awake() => Instance = this;
@@ -53,7 +53,11 @@ public class SimulationManager : MonoBehaviour
         {
             isHalted = true;
             Time.timeScale = 0;
-            //SceneManager.LoadScene(SummarySceneName);
+
+            if (simulationSceneHandler != null)
+            {
+                simulationSceneHandler.QuitToScoreSummary();
+            }
         }
     }
 }

--- a/LifeSimulation/Assets/Scripts/SimulationSceneHandler.cs
+++ b/LifeSimulation/Assets/Scripts/SimulationSceneHandler.cs
@@ -1,0 +1,157 @@
+// -----------------------------------------------------------------------------
+// Project:		EXTENDED LIFE SIMULATION CAPSTONE ASSIGNMENT
+// Item:		Simulation scene UI
+// Requirement:	Leaderboard
+// Author:		Benjamin Jones
+// Date:		04/14/2026
+// Version:		0.0.0
+//
+// Description:
+//    Handles simulation quit flow and prepares score summary values.
+// -----------------------------------------------------------------------------
+
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.UI;
+using TMPro;
+
+/// <summary> Handles Simulation scene UI actions related to score summary. </summary>
+public class SimulationSceneHandler : MonoBehaviour
+{
+    [Header("Scene Configuration")]
+    public string scoreSummarySceneName = "ScoreSummary";
+
+    [Header("References")]
+    public LogManager logManager;
+    public SimulationLogger simulationLogger;
+    public PopTracker popTracker;
+
+    void Start()
+    {
+        AutoAssignReferences();
+        EnsureEditorPanelQuitButton();
+    }
+
+    /// <summary> Finalizes run values and opens score summary scene. </summary>
+    public void QuitToScoreSummary()
+    {
+        Debug.Log("Simulation Quit Selected");
+
+        if (logManager != null && simulationLogger != null)
+        {
+            logManager.LogFinalSnapshot();
+            ScoreSummaryPayload generated = SummaryGenerator.GenerateSummaryPayload(simulationLogger.filepath);
+            ScoreSummaryData.SetCurrentRun(generated);
+        }
+        else
+        {
+            ScoreSummaryData.SetCurrentRun(BuildFallbackPayload());
+        }
+
+        Time.timeScale = 1f;
+        SceneManager.LoadScene(scoreSummarySceneName);
+    }
+
+    /// <summary> UI alias that mirrors other scene button naming. </summary>
+    public void Quit()
+    {
+        QuitToScoreSummary();
+    }
+
+    /// <summary> Placeholder for future auto-end trigger integration. </summary>
+    public void AutoEndToScoreSummary()
+    {
+        // Reserved for future implementation.
+    }
+
+    private ScoreSummaryPayload BuildFallbackPayload()
+    {
+        PopSnapshot snapshot = popTracker != null ? popTracker.GetSnapshot(0) : new PopSnapshot(0, 0, 0, 0);
+        int diversity = 0;
+        diversity += snapshot.plantCount > 0 ? 1 : 0;
+        diversity += snapshot.grazerCount > 0 ? 1 : 0;
+        diversity += snapshot.predatorCount > 0 ? 1 : 0;
+
+        return new ScoreSummaryPayload
+        {
+            longestSurvivalTime = 0,
+            highestPopulationPeak = snapshot.totalPop,
+            highestDiversity = diversity,
+            highestStability = 0,
+            overallScore = snapshot.totalPop
+        };
+    }
+
+    private void EnsureEditorPanelQuitButton()
+    {
+        GameObject editorPanel = GameObject.Find("EditorPanel");
+        if (editorPanel == null)
+        {
+            return;
+        }
+
+        Transform existing = editorPanel.transform.Find("QuitToSummaryButton");
+        if (existing == null)
+        {
+            existing = editorPanel.transform.Find("Quit");
+        }
+
+        if (existing != null)
+        {
+            existing.name = "Quit";
+            Button existingButton = existing.GetComponent<Button>();
+            if (existingButton != null)
+            {
+                existingButton.onClick.RemoveAllListeners();
+                existingButton.onClick.AddListener(Quit);
+            }
+            return;
+        }
+
+        GameObject buttonObject = new GameObject("Quit", typeof(RectTransform), typeof(Image), typeof(Button));
+        buttonObject.transform.SetParent(editorPanel.transform, false);
+        RectTransform rect = buttonObject.GetComponent<RectTransform>();
+        rect.sizeDelta = new Vector2(160f, 30f);
+        rect.anchorMin = new Vector2(0f, 0f);
+        rect.anchorMax = new Vector2(0f, 0f);
+        rect.anchoredPosition = new Vector2(0f, -200f);
+
+        Image image = buttonObject.GetComponent<Image>();
+        image.color = new Color32(27, 182, 176, 255);
+
+        Button button = buttonObject.GetComponent<Button>();
+        button.onClick.AddListener(Quit);
+
+        GameObject labelObject = new GameObject("Text (TMP)", typeof(RectTransform), typeof(TextMeshProUGUI));
+        labelObject.transform.SetParent(buttonObject.transform, false);
+        RectTransform labelRect = labelObject.GetComponent<RectTransform>();
+        labelRect.anchorMin = Vector2.zero;
+        labelRect.anchorMax = Vector2.one;
+        labelRect.offsetMin = Vector2.zero;
+        labelRect.offsetMax = Vector2.zero;
+
+        TextMeshProUGUI label = labelObject.GetComponent<TextMeshProUGUI>();
+        label.text = "Quit";
+        label.alignment = TextAlignmentOptions.Center;
+        label.fontSize = 24;
+        label.color = new Color32(50, 50, 50, 255);
+    }
+
+    private void AutoAssignReferences()
+    {
+        if (logManager == null)
+        {
+            logManager = FindFirstObjectByType<LogManager>();
+        }
+
+        if (simulationLogger == null)
+        {
+            simulationLogger = FindFirstObjectByType<SimulationLogger>();
+        }
+
+        if (popTracker == null)
+        {
+            popTracker = FindFirstObjectByType<PopTracker>();
+        }
+    }
+}

--- a/LifeSimulation/Assets/Scripts/SimulationSceneHandler.cs
+++ b/LifeSimulation/Assets/Scripts/SimulationSceneHandler.cs
@@ -7,7 +7,10 @@
 // Version:		0.0.0
 //
 // Description:
-//    Handles simulation quit flow and prepares score summary values.
+//    Simulation scene: on quit/finish, finalizes logging, builds
+//    ScoreSummaryPayload (SummaryGenerator or fallback from PopTracker), stores
+//    it in ScoreSummaryData, then loads ScoreSummary. Ensures Quit control on
+//    EditorPanel when present.
 // -----------------------------------------------------------------------------
 
 using UnityEngine;
@@ -15,7 +18,7 @@ using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 using TMPro;
 
-/// <summary> Handles Simulation scene UI actions related to score summary. </summary>
+/// <summary> End-of-run transition from Simulation to score summary scene. </summary>
 public class SimulationSceneHandler : MonoBehaviour
 {
     [Header("Scene Configuration")]
@@ -56,12 +59,6 @@ public class SimulationSceneHandler : MonoBehaviour
     public void Quit()
     {
         QuitToScoreSummary();
-    }
-
-    /// <summary> Placeholder for future auto-end trigger integration. </summary>
-    public void AutoEndToScoreSummary()
-    {
-        // Reserved for future implementation.
     }
 
     private ScoreSummaryPayload BuildFallbackPayload()

--- a/LifeSimulation/Assets/Scripts/SimulationSceneHandler.cs
+++ b/LifeSimulation/Assets/Scripts/SimulationSceneHandler.cs
@@ -28,6 +28,7 @@ public class SimulationSceneHandler : MonoBehaviour
     public LogManager logManager;
     public SimulationLogger simulationLogger;
     public PopTracker popTracker;
+    public MapGenerator2D mapGenerator;
 
     void Start()
     {
@@ -40,7 +41,12 @@ public class SimulationSceneHandler : MonoBehaviour
     {
         Debug.Log("Simulation Quit Selected");
 
-        if (logManager != null && simulationLogger != null)
+        if (!HasSimulationStarted())
+        {
+            // Leave the scene anytime; no run was started so scores stay default zeros.
+            ScoreSummaryData.SetCurrentRun(new ScoreSummaryPayload());
+        }
+        else if (logManager != null && simulationLogger != null)
         {
             logManager.LogFinalSnapshot();
             ScoreSummaryPayload generated = SummaryGenerator.GenerateSummaryPayload(simulationLogger.filepath);
@@ -150,6 +156,11 @@ public class SimulationSceneHandler : MonoBehaviour
 
     private void AutoAssignReferences()
     {
+        if (mapGenerator == null)
+        {
+            mapGenerator = FindFirstObjectByType<MapGenerator2D>();
+        }
+
         if (logManager == null)
         {
             logManager = FindFirstObjectByType<LogManager>();
@@ -164,5 +175,10 @@ public class SimulationSceneHandler : MonoBehaviour
         {
             popTracker = FindFirstObjectByType<PopTracker>();
         }
+    }
+
+    private bool HasSimulationStarted()
+    {
+        return mapGenerator != null && mapGenerator.HasSimulationStarted && mapGenerator.IsMapReady;
     }
 }

--- a/LifeSimulation/Assets/Scripts/SimulationSceneHandler.cs
+++ b/LifeSimulation/Assets/Scripts/SimulationSceneHandler.cs
@@ -63,7 +63,21 @@ public class SimulationSceneHandler : MonoBehaviour
 
     private ScoreSummaryPayload BuildFallbackPayload()
     {
-        PopSnapshot snapshot = popTracker != null ? popTracker.GetSnapshot(0) : new PopSnapshot(0, 0, 0, 0);
+        PopSnapshot snapshot;
+        if (popTracker != null)
+        {
+            snapshot = popTracker.GetSnapshot(0);
+        }
+        else if (EcosystemManager.Instance != null)
+        {
+            EcosystemManager eco = EcosystemManager.Instance;
+            snapshot = new PopSnapshot(0, eco.PlantCount, eco.GrazerCount, eco.PredatorCount);
+        }
+        else
+        {
+            snapshot = new PopSnapshot(0, 0, 0, 0);
+        }
+
         int diversity = 0;
         diversity += snapshot.plantCount > 0 ? 1 : 0;
         diversity += snapshot.grazerCount > 0 ? 1 : 0;

--- a/LifeSimulation/Assets/Scripts/SimulationSceneHandler.cs.meta
+++ b/LifeSimulation/Assets/Scripts/SimulationSceneHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0d9a4d9e8c434ce0a4d31e4f4f32a08e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/LifeSimulation/Assets/Scripts/UIHandler.cs
+++ b/LifeSimulation/Assets/Scripts/UIHandler.cs
@@ -12,6 +12,7 @@
 
 using UnityEngine;
 using TMPro;
+using System.Collections.Generic;
 
 /// <summary> Handles UI element and simulation interaction </summary>
 public class UIHandler : MonoBehaviour
@@ -23,6 +24,21 @@ public class UIHandler : MonoBehaviour
 
     [Header("Generator Reference")]
     public MapGenerator2D mapGenerator;
+    [Header("Spawn Button Visibility")]
+    [Tooltip("Optional explicit button list. If empty, buttons are auto-found by name.")]
+    public List<GameObject> spawnEntityButtons = new List<GameObject>();
+
+    [Header("Generate Map Button")]
+    [Tooltip("If unset, looks for GameObject named GenerateMapButton. Hidden once simulation has started.")]
+    public GameObject generateMapButton;
+
+    void Start()
+    {
+        AutoAssignSpawnButtonsIfNeeded();
+        AutoAssignGenerateMapButtonIfNeeded();
+        UpdateSpawnButtonsVisibility(false);
+        SetGenerateMapButtonVisible(true);
+    }
 
     /// <summary> Triggers upon Map Generate button being clicked </summary>
     public void OnClickGenerate()
@@ -34,7 +50,73 @@ public class UIHandler : MonoBehaviour
         int width = int.TryParse(widthInput.text, out int w) ? w : 250;
         int height = int.TryParse(heightInput.text, out int h) ? h : 250;
 
+        if (mapGenerator == null)
+        {
+            return;
+        }
+
         // Pass taken data to map generation script
         mapGenerator.GenerateMap(seed, width, height);
+        bool started = mapGenerator.IsMapReady && mapGenerator.HasSimulationStarted;
+        UpdateSpawnButtonsVisibility(started);
+        SetGenerateMapButtonVisible(!started);
+    }
+
+    private void AutoAssignSpawnButtonsIfNeeded()
+    {
+        if (spawnEntityButtons != null && spawnEntityButtons.Count > 0)
+        {
+            return;
+        }
+
+        string[] buttonNames =
+        {
+            "SpawnGrazerButton",
+            "SpawnPredatorButton",
+            "SpawnPlantButton"
+        };
+
+        foreach (string buttonName in buttonNames)
+        {
+            GameObject button = GameObject.Find(buttonName);
+            if (button != null)
+            {
+                spawnEntityButtons.Add(button);
+            }
+        }
+    }
+
+    private void UpdateSpawnButtonsVisibility(bool isVisible)
+    {
+        if (spawnEntityButtons == null)
+        {
+            return;
+        }
+
+        foreach (GameObject button in spawnEntityButtons)
+        {
+            if (button != null)
+            {
+                button.SetActive(isVisible);
+            }
+        }
+    }
+
+    private void AutoAssignGenerateMapButtonIfNeeded()
+    {
+        if (generateMapButton != null)
+        {
+            return;
+        }
+
+        generateMapButton = GameObject.Find("GenerateMapButton");
+    }
+
+    private void SetGenerateMapButtonVisible(bool isVisible)
+    {
+        if (generateMapButton != null)
+        {
+            generateMapButton.SetActive(isVisible);
+        }
     }
 }

--- a/LifeSimulation/Assets/Scripts/WorldEditor.cs
+++ b/LifeSimulation/Assets/Scripts/WorldEditor.cs
@@ -14,7 +14,9 @@ using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.EventSystems;
 using UnityEngine.Tilemaps;
-using System.Diagnostics;
+#if ENABLE_LEGACY_INPUT_MANAGER
+using LegacyInput = UnityEngine.Input;
+#endif
 
 /// <summary> Executes mouse-driven object placement logic </summary>
 public class WorldEditor : MonoBehaviour
@@ -26,18 +28,65 @@ public class WorldEditor : MonoBehaviour
     public GameObject plantPrefab;
     public GameObject obstaclePrefab;
 
+    [Header("Optional")]
+    [Tooltip("When using UI buttons, also spawn one entity immediately (recommended).")]
+    [SerializeField] private bool spawnOneOnButtonSelect = true;
+
+    [Tooltip("Attempts to find a random tile with HasTile before giving up.")]
+    [SerializeField] private int randomTileMaxAttempts = 96;
+
     // Stores selected placement mode
     private int selection = 0;
 
     /// <summary> Listens for mouse input every frame </summary>
     void Update()
     {
-        // prevent spawning while mousing over UI
-        if (Mouse.current.leftButton.wasPressedThisFrame && selection != 0 && !EventSystem.current.IsPointerOverGameObject())
+        if (selection == 0)
         {
-            UnityEngine.Debug.Log($"Click detected. Selection: {selection}, OverUI: {EventSystem.current.IsPointerOverGameObject()}");
-            SpawnAtMouse();
+            return;
         }
+
+        if (!WasPrimaryClickPressedThisFrame())
+        {
+            return;
+        }
+
+        // Input System UI module: must pass device id; parameterless IsPointerOverGameObject often blocks all game-view clicks.
+        if (IsPointerOverUiBlockingGame())
+        {
+            return;
+        }
+
+        UnityEngine.Debug.Log($"Click detected. Selection: {selection}");
+        SpawnAtMouse();
+    }
+
+    private static bool WasPrimaryClickPressedThisFrame()
+    {
+        if (Mouse.current != null && Mouse.current.leftButton.wasPressedThisFrame)
+        {
+            return true;
+        }
+#if ENABLE_LEGACY_INPUT_MANAGER
+        return LegacyInput.GetMouseButtonDown(0);
+#else
+        return false;
+#endif
+    }
+
+    private static bool IsPointerOverUiBlockingGame()
+    {
+        if (EventSystem.current == null)
+        {
+            return false;
+        }
+
+        if (Mouse.current != null)
+        {
+            return EventSystem.current.IsPointerOverGameObject(Mouse.current.deviceId);
+        }
+
+        return EventSystem.current.IsPointerOverGameObject();
     }
 
     /// <summary> Updates current selection of lifeform to place from UI buttons </summary>
@@ -46,50 +95,158 @@ public class WorldEditor : MonoBehaviour
     {
         selection = type;
         UnityEngine.Debug.Log("Editor Mode: " + selection);
+
+        if (spawnOneOnButtonSelect)
+        {
+            TrySpawnAtRandomOccupiedCell();
+        }
+    }
+
+    /// <summary> Same as SetSelection but explicit name for UI wiring (spawns one if spawnOneOnButtonSelect is on).</summary>
+    public void SelectAndSpawnOne(int type)
+    {
+        SetSelection(type);
     }
 
     /// <summary> creates prefab of lifeform selection at mouse location </summary>
     void SpawnAtMouse()
     {
-        // convert screen-space mouse position to 2D coordinates
         UnityEngine.Debug.Log("SpawnAtMouse called");
-        Vector2 mousePosition = Mouse.current.position.ReadValue();
-        Vector3 mousePos = Camera.main.ScreenToWorldPoint(Input.mousePosition);
-        mousePos.z = 0;
+        if (squareTilemap == null || Camera.main == null)
+        {
+            return;
+        }
 
-        Vector3Int cellPos = squareTilemap.WorldToCell(mousePos);
+        if (!TryGetWorldPointOnTilemapPlane(GetPointerScreenPosition(), out Vector3 worldOnPlane))
+        {
+            return;
+        }
 
-        UnityEngine.Debug.Log($"HasTile: {squareTilemap.HasTile(cellPos)}, CellPos: {cellPos}, toSpawn null: {plantPrefab == null}");
+        TrySpawnAtWorldPosition(worldOnPlane);
+    }
 
+    private bool TrySpawnAtRandomOccupiedCell()
+    {
+        if (squareTilemap == null || Camera.main == null || EcosystemManager.Instance == null)
+        {
+            return false;
+        }
 
-            if (squareTilemap.HasTile(cellPos))
+        BoundsInt b = squareTilemap.cellBounds;
+        if (b.size.x <= 0 || b.size.y <= 0)
+        {
+            return false;
+        }
+
+        for (int attempt = 0; attempt < randomTileMaxAttempts; attempt++)
+        {
+            Vector3Int cell = new Vector3Int(
+                Random.Range(b.xMin, b.xMax),
+                Random.Range(b.yMin, b.yMax),
+                b.zMin);
+
+            if (squareTilemap.HasTile(cell))
             {
-                Vector3 spawnPos = squareTilemap.GetCellCenterWorld(cellPos);
-                spawnPos.z = 0;
-                string id = "";
-                UnityEngine.Debug.Log($"EcosystemManager null: {EcosystemManager.Instance == null}");
-                switch (selection)
-                {
-                    case 1:
-                        id = "Grazer";
-                        EcosystemManager.Instance.ManualSpawnGrazer(spawnPos);
-                        break;
-                    case 2:
-                        id = "Predator";
-                        EcosystemManager.Instance.ManualSpawnPredator(spawnPos);
-                        break;
-                    case 3:
-                        id = "Plant";
-                        EcosystemManager.Instance.ManualSpawnPlant(spawnPos);
-                        break;
-                    case 4:
-                        id = "Obstacle";
-                        Instantiate(obstaclePrefab, spawnPos, Quaternion.identity);
-                        break;
-                }
-
-                if (id != "")
-                    SimulationManager.Instance.UpdatePopulation(id, 1);
+                Vector3 spawnPos = squareTilemap.GetCellCenterWorld(cell);
+                spawnPos.z = squareTilemap.transform.position.z;
+                return TrySpawnAtWorldPosition(spawnPos);
             }
+        }
+
+        return false;
+    }
+
+    private bool TrySpawnAtWorldPosition(Vector3 worldOnPlane)
+    {
+        if (squareTilemap == null || EcosystemManager.Instance == null)
+        {
+            return false;
+        }
+
+        Vector3Int cellPos = squareTilemap.WorldToCell(worldOnPlane);
+
+        UnityEngine.Debug.Log($"HasTile: {squareTilemap.HasTile(cellPos)}, CellPos: {cellPos}");
+
+        if (!squareTilemap.HasTile(cellPos))
+        {
+            return false;
+        }
+
+        Vector3 spawnPos = squareTilemap.GetCellCenterWorld(cellPos);
+        spawnPos.z = squareTilemap.transform.position.z;
+        string id = "";
+        switch (selection)
+        {
+            case 1:
+                id = "Grazer";
+                EcosystemManager.Instance.ManualSpawnGrazer(spawnPos);
+                break;
+            case 2:
+                id = "Predator";
+                EcosystemManager.Instance.ManualSpawnPredator(spawnPos);
+                break;
+            case 3:
+                id = "Plant";
+                EcosystemManager.Instance.ManualSpawnPlant(spawnPos);
+                break;
+            case 4:
+                id = "Obstacle";
+                if (obstaclePrefab != null)
+                {
+                    Instantiate(obstaclePrefab, spawnPos, Quaternion.identity);
+                }
+                break;
+        }
+
+        if (id != "" && SimulationManager.Instance != null)
+        {
+            SimulationManager.Instance.UpdatePopulation(id, 1);
+        }
+
+        return true;
+    }
+
+    private static Vector2 GetPointerScreenPosition()
+    {
+        if (Mouse.current != null)
+        {
+            return Mouse.current.position.ReadValue();
+        }
+#if ENABLE_LEGACY_INPUT_MANAGER
+        return LegacyInput.mousePosition;
+#else
+        return Vector2.zero;
+#endif
+    }
+
+    /// <summary>
+    /// Orthographic + Input.mouse z=0 breaks ScreenToWorldPoint; intersect the camera ray with the tilemap Z plane.
+    /// </summary>
+    private bool TryGetWorldPointOnTilemapPlane(Vector2 screenPx, out Vector3 worldPoint)
+    {
+        worldPoint = default;
+        Camera cam = Camera.main;
+        if (cam == null || squareTilemap == null)
+        {
+            return false;
+        }
+
+        float planeZ = squareTilemap.transform.position.z;
+        Ray ray = cam.ScreenPointToRay(new Vector3(screenPx.x, screenPx.y, 0f));
+
+        if (Mathf.Abs(ray.direction.z) > 1e-5f)
+        {
+            float t = (planeZ - ray.origin.z) / ray.direction.z;
+            if (t >= 0f)
+            {
+                worldPoint = ray.GetPoint(t);
+                return true;
+            }
+        }
+
+        // Fallback: distance from camera to plane along forward (typical 2D setup).
+        float fallbackZ = Mathf.Abs(cam.transform.position.z - planeZ);
+        worldPoint = cam.ScreenToWorldPoint(new Vector3(screenPx.x, screenPx.y, fallbackZ));
+        return true;
     }
 }

--- a/LifeSimulation/Assets/Scripts/WorldEditor.cs
+++ b/LifeSimulation/Assets/Scripts/WorldEditor.cs
@@ -23,6 +23,10 @@ public class WorldEditor : MonoBehaviour
 {
     [Header("Dependancies")]
     public Tilemap squareTilemap;
+
+    [Tooltip("If unset, uses MapGenerator2D on the same GameObject. Spawns are blocked until Generate Map has finished.")]
+    [SerializeField] private MapGenerator2D mapGenerator;
+
     public GameObject grazerPrefab;
     public GameObject predatorPrefab;
     public GameObject plantPrefab;
@@ -32,11 +36,28 @@ public class WorldEditor : MonoBehaviour
     [Tooltip("When using UI buttons, also spawn one entity immediately (recommended).")]
     [SerializeField] private bool spawnOneOnButtonSelect = true;
 
-    [Tooltip("Attempts to find a random tile with HasTile before giving up.")]
+    [Tooltip("Fallback attempts if open-tile list is unavailable (should be rare).")]
     [SerializeField] private int randomTileMaxAttempts = 96;
 
     // Stores selected placement mode
     private int selection = 0;
+
+    void Awake()
+    {
+        if (mapGenerator == null)
+        {
+            mapGenerator = GetComponent<MapGenerator2D>();
+        }
+    }
+
+    private bool CanSpawnOnMap()
+    {
+        return mapGenerator != null
+               && mapGenerator.IsMapReady
+               && mapGenerator.HasSimulationStarted
+               && squareTilemap != null
+               && EcosystemManager.Instance != null;
+    }
 
     /// <summary> Listens for mouse input every frame </summary>
     void Update()
@@ -53,6 +74,11 @@ public class WorldEditor : MonoBehaviour
 
         // Input System UI module: must pass device id; parameterless IsPointerOverGameObject often blocks all game-view clicks.
         if (IsPointerOverUiBlockingGame())
+        {
+            return;
+        }
+
+        if (!CanSpawnOnMap())
         {
             return;
         }
@@ -93,12 +119,17 @@ public class WorldEditor : MonoBehaviour
     /// <param name="type"> Integer ID of selection type </param>
     public void SetSelection(int type)
     {
+        if (!CanSpawnOnMap())
+        {
+            return;
+        }
+
         selection = type;
         UnityEngine.Debug.Log("Editor Mode: " + selection);
 
         if (spawnOneOnButtonSelect)
         {
-            TrySpawnAtRandomOccupiedCell();
+            TrySpawnAtRandomOpenTile();
         }
     }
 
@@ -112,7 +143,7 @@ public class WorldEditor : MonoBehaviour
     void SpawnAtMouse()
     {
         UnityEngine.Debug.Log("SpawnAtMouse called");
-        if (squareTilemap == null || Camera.main == null)
+        if (!CanSpawnOnMap() || Camera.main == null)
         {
             return;
         }
@@ -125,13 +156,21 @@ public class WorldEditor : MonoBehaviour
         TrySpawnAtWorldPosition(worldOnPlane);
     }
 
-    private bool TrySpawnAtRandomOccupiedCell()
+    /// <summary> Spawns one entity on a random walkable tile (same pool as initial sim spawns — avoids obstacles).</summary>
+    private bool TrySpawnAtRandomOpenTile()
     {
-        if (squareTilemap == null || Camera.main == null || EcosystemManager.Instance == null)
+        if (!CanSpawnOnMap())
         {
             return false;
         }
 
+        if (mapGenerator.TryGetRandomOpenTileWorldPosition(out Vector3 worldCenter))
+        {
+            worldCenter.z = squareTilemap.transform.position.z;
+            return TrySpawnAtWorldPosition(worldCenter);
+        }
+
+        // Fallback: uniform random cell in bounds (may include obstacle cells)
         BoundsInt b = squareTilemap.cellBounds;
         if (b.size.x <= 0 || b.size.y <= 0)
         {
@@ -141,8 +180,8 @@ public class WorldEditor : MonoBehaviour
         for (int attempt = 0; attempt < randomTileMaxAttempts; attempt++)
         {
             Vector3Int cell = new Vector3Int(
-                Random.Range(b.xMin, b.xMax),
-                Random.Range(b.yMin, b.yMax),
+                UnityEngine.Random.Range(b.xMin, b.xMax),
+                UnityEngine.Random.Range(b.yMin, b.yMax),
                 b.zMin);
 
             if (squareTilemap.HasTile(cell))
@@ -158,7 +197,7 @@ public class WorldEditor : MonoBehaviour
 
     private bool TrySpawnAtWorldPosition(Vector3 worldOnPlane)
     {
-        if (squareTilemap == null || EcosystemManager.Instance == null)
+        if (!CanSpawnOnMap())
         {
             return false;
         }

--- a/LifeSimulation/ProjectSettings/EditorBuildSettings.asset
+++ b/LifeSimulation/ProjectSettings/EditorBuildSettings.asset
@@ -17,6 +17,9 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/Leaderboard.unity
     guid: 8345b5f4cef5a5d43b4bb90b70679136
+  - enabled: 1
+    path: Assets/Scenes/ScoreSummary.unity
+    guid: ea532f2bb3e9473a8c3ef9d3b0d86ef5
   m_configObjects:
     com.unity.input.settings.actions: {fileID: -944628639613478452, guid: 2bcd2660ca9b64942af0de543d8d7100, type: 3}
   m_UseUCBPForAssetBundles: 0

--- a/LifeSimulation/ProjectSettings/ProjectSettings.asset
+++ b/LifeSimulation/ProjectSettings/ProjectSettings.asset
@@ -692,7 +692,7 @@ PlayerSettings:
   hmiLoadingImage: {fileID: 0}
   platformRequiresReadableAssets: 0
   virtualTexturingSupportEnabled: 0
-  insecureHttpOption: 0
+  insecureHttpOption: 2
   androidVulkanDenyFilterList: []
   androidVulkanAllowFilterList: []
   androidVulkanDeviceFilterListAsset: {fileID: 0}


### PR DESCRIPTION
## Summary
- Adds a full run-end score submission pipeline: simulation quit/finalization now builds a `ScoreSummaryPayload`, transitions to a new `ScoreSummary` scene, and submits all five leaderboard categories.
- Introduces Nakama client integration scripts for device auth, leaderboard write/read calls, arcade-style disposable identity support, and metadata-based display name handling (`metadata.name`) for leaderboard row rendering.
- Updates leaderboard UI data binding and supporting logging/summary generation code so score values shown in summary and leaderboard are sourced from generated run data rather than static placeholders.
- Adds project/scene/editor support changes required for this flow (`ScoreSummary.unity` added to build settings, HTTP downloads setting enforcement for editor, simulation scene quit wiring).

## Scope of files changed
- New: `Assets/Scripts/Leaderboard/NakamaLeaderboardService.cs`, `Assets/Scripts/Leaderboard/ScoreSummaryData.cs`, `Assets/Scripts/Leaderboard/ScoreSummaryHandler.cs`, `Assets/Scripts/SimulationSceneHandler.cs`, `Assets/Scenes/ScoreSummary.unity`, `Assets/Editor/EnforceHttpDownloadsSetting.cs`, and related `.meta` files.
- Updated: `Assets/Scripts/LeaderboardSceneHandler.cs`, `Assets/Scripts/Logging/SummaryGenerator.cs`, `Assets/Scripts/Logging/PopTracker.cs`, `Assets/Scripts/SimulationManager.cs`, `Assets/Scenes/Simulation.unity`, `ProjectSettings/EditorBuildSettings.asset`, `ProjectSettings/ProjectSettings.asset`.

## Behavior now covered
- Simulation can end via quit/auto-finalization and route to ScoreSummary.
- ScoreSummary displays the five categories, accepts name input, submits category scores to Nakama, and returns to main menu.
- Leaderboard scene fetches records per category and resolves display name from metadata first.