### PR TITLE
Refactor map generation; update prefabs & UI

### DIFF
--- a/LifeSimulation/Assets/Placeholder_Grazer.prefab
+++ b/LifeSimulation/Assets/Placeholder_Grazer.prefab
@@ -140,7 +140,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -334.5276, y: -633.0797, z: 0}
-  m_LocalScale: {x: 0.25, y: 0.25, z: 1}
+  m_LocalScale: {x: 1.25, y: 1.25, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 295553643726941787}
@@ -195,12 +195,12 @@ SpriteRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_MaskInteraction: 0
-  m_Sprite: {fileID: -3337038689812066966, guid: 2a4335b3feece0e4b8cc35d4c89c7c2a, type: 3}
+  m_Sprite: {fileID: 2912297781628502651, guid: 862a9a67b8794e046ad207fb3249b3b9, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
+  m_Size: {x: 1.6, y: 1.41}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
@@ -244,7 +244,7 @@ BoxCollider2D:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
     oldSize: {x: 1.6, y: 1.41}
-    newSize: {x: 1, y: 1}
+    newSize: {x: 1.6, y: 1.41}
     adaptiveTilingThreshold: 0.5
     drawMode: 0
     adaptiveTiling: 0

--- a/LifeSimulation/Assets/Placeholder_Obstacle.prefab
+++ b/LifeSimulation/Assets/Placeholder_Obstacle.prefab
@@ -29,7 +29,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 4.04179, y: 4.32992, z: 0}
-  m_LocalScale: {x: 0.5, y: 0.5, z: 1}
+  m_LocalScale: {x: 1.5, y: 1.5, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -83,12 +83,12 @@ SpriteRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_MaskInteraction: 0
-  m_Sprite: {fileID: -5513050994037168576, guid: 70ce10590f8445940aa1fd7539f7e806, type: 3}
+  m_Sprite: {fileID: 6097263166143520310, guid: 34e7e4c2e14bfb148bbfd0a3f2802e81, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
+  m_Size: {x: 1.42, y: 1.42}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
@@ -132,7 +132,7 @@ BoxCollider2D:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
     oldSize: {x: 1.42, y: 1.42}
-    newSize: {x: 1, y: 1}
+    newSize: {x: 1.42, y: 1.42}
     adaptiveTilingThreshold: 0.5
     drawMode: 0
     adaptiveTiling: 0

--- a/LifeSimulation/Assets/Placeholder_Plant.prefab
+++ b/LifeSimulation/Assets/Placeholder_Plant.prefab
@@ -31,7 +31,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -334.5276, y: -633.0797, z: 0}
-  m_LocalScale: {x: 0.25, y: 0.25, z: 1}
+  m_LocalScale: {x: 1.25, y: 1.25, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -85,12 +85,12 @@ SpriteRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_MaskInteraction: 0
-  m_Sprite: {fileID: -168421969075237668, guid: fa23e4a29abd2284d83653330b450d7c, type: 3}
+  m_Sprite: {fileID: 7560591164928645431, guid: 034ba2da5d146f643b4818e76ade13a4, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
+  m_Size: {x: 1.42, y: 1.32}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
@@ -134,7 +134,7 @@ BoxCollider2D:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
     oldSize: {x: 1.42, y: 1.32}
-    newSize: {x: 1, y: 1}
+    newSize: {x: 1.42, y: 1.32}
     adaptiveTilingThreshold: 0.5
     drawMode: 0
     adaptiveTiling: 0

--- a/LifeSimulation/Assets/Placeholder_Predator.prefab
+++ b/LifeSimulation/Assets/Placeholder_Predator.prefab
@@ -36,7 +36,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -334.5276, y: -633.0797, z: 0}
-  m_LocalScale: {x: 0.25, y: 0.25, z: 1}
+  m_LocalScale: {x: 1.25, y: 1.25, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4893211788373248962}
@@ -91,12 +91,12 @@ SpriteRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_MaskInteraction: 0
-  m_Sprite: {fileID: 4483504832982471387, guid: 0d4efbdb5b39ab4448b58f9182b79816, type: 3}
+  m_Sprite: {fileID: 358550201270088617, guid: 6652824b67c359e46a37728180585f21, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
+  m_Size: {x: 1.42, y: 1.41}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
@@ -140,7 +140,7 @@ BoxCollider2D:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
     oldSize: {x: 1.42, y: 1.41}
-    newSize: {x: 1, y: 1}
+    newSize: {x: 1.42, y: 1.41}
     adaptiveTilingThreshold: 0.5
     drawMode: 0
     adaptiveTiling: 0

--- a/LifeSimulation/Assets/Scripts/Config/SimulationSettingsStore.cs
+++ b/LifeSimulation/Assets/Scripts/Config/SimulationSettingsStore.cs
@@ -204,11 +204,6 @@ public class SimulationSettingsStore : MonoBehaviour
         UIHandler ui = FindFirstObjectByType<UIHandler>();
         if (ui == null)
             return;
-
-        if (ui.widthInput != null)
-            ui.widthInput.SetTextWithoutNotify(Current.terrain.mapWidth.ToString());
-        if (ui.heightInput != null)
-            ui.heightInput.SetTextWithoutNotify(Current.terrain.mapHeight.ToString());
     }
 
     void ApplyEcosystem()

--- a/LifeSimulation/Assets/Scripts/EnvironmentHandler.cs
+++ b/LifeSimulation/Assets/Scripts/EnvironmentHandler.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------------
 // Project:		EXTENDED LIFE SIMULATION CAPSTONE ASSIGNMENT
 // Item:		Environment & Resource Management
 // Requirement:	Environmental Variation, Seasonal Growth, Lighting

--- a/LifeSimulation/Assets/Scripts/MapGenerator2D.cs
+++ b/LifeSimulation/Assets/Scripts/MapGenerator2D.cs
@@ -1,3 +1,13 @@
+// -----------------------------------------------------------------------------
+// Project:     EXTENDED LIFE SIMULATION CAPSTONE ASSIGNMENT
+// Item:        Simulation GUI
+// Requirement: Sim Editor
+// Author:      Robert Amborski
+// Date:        3/25/2026
+// Version:     0.0.1
+//
+// Description:
+//    Generates a square tilemap using a provided seed and specified X/Y dimensions.
 //    After map generation, spawns initial obstacles, plants, grazers, and predators.
 // -----------------------------------------------------------------------------
 using System;
@@ -52,11 +62,24 @@ public class MapGenerator2D : MonoBehaviour
     public bool HasSimulationStarted { get; private set; }
 
     /// <summary> Executes map generation logic then spawns initial entities </summary>
-    /// <param name="seed"> String used to seed the RNG </param>
-    /// <param name="width"> Width of map in tiles </param>
-    /// <param name="height"> Height of map in tiles </param>
-    public void GenerateMap(string seed, int width, int height)
+    public void GenerateMap()
     {
+        IsMapReady = false;
+        HasSimulationStarted = false;
+
+        // Determine dimensions from central spectator settings
+        int sizeDim = 500;
+        var camHandler = FindFirstObjectByType<CameraHandler>();
+        if (camHandler != null)
+        {
+            switch (camHandler.selectedSize)
+            {
+                case CameraHandler.MapSize.Small: sizeDim = 150; break;
+                case CameraHandler.MapSize.Medium: sizeDim = 300; break;
+                case CameraHandler.MapSize.Large: sizeDim = 500; break;
+            }
+        }
+
         // Wipe existing data to prepare for new generation
         squareTilemap.ClearAllTiles();
         _openTiles.Clear();
@@ -67,27 +90,39 @@ public class MapGenerator2D : MonoBehaviour
         DestroyTagged("Predator");
         DestroyTagged("Obstacle");
 
-        // Convert string hash to initialize random state
-        UnityEngine.Random.InitState(seed.GetHashCode());
+        // Initialize unique seed for sim run
+        UnityEngine.Random.InitState((int)DateTime.Now.Ticks);
+        float offsetX = UnityEngine.Random.Range(0f, 99999f);
+        float offsetY = UnityEngine.Random.Range(0f, 99999f);
+
+        // calculate offset for centering
+        int halfDim = sizeDim / 2;
+        Vector3Int startPos = new Vector3Int(-halfDim, -halfDim, 0);
+        Vector3Int size = new Vector3Int(sizeDim, sizeDim, 1);
+
+        // Batch set tiles to avoid CPU overhead
+        BoundsInt bounds = new BoundsInt(startPos, size);
+        TileBase[] tileArray = new TileBase[sizeDim * sizeDim];
+
+        for (int i = 0; i < tileArray.Length; i++) tileArray[i] = baseSquareTile;
+        squareTilemap.SetTilesBlock(bounds, tileArray);
 
         // ── Tile placement ────────────────────────────────────────────────────
-        for (int x = 0; x < width; x++)
+        for (int x = -halfDim; x < halfDim; x++)
         {
-            for (int y = 0; y < height; y++)
+            for (int y = -halfDim; y < halfDim; y++)
             {
                 Vector3Int tilePos = new Vector3Int(x, y, 0);
                 squareTilemap.SetTile(tilePos, baseSquareTile);
 
-                float perlin = Mathf.PerlinNoise(x * 0.1f, y * 0.1f);
-                Color tileColor = (perlin > 0.67f)
-                    ? new Color(0.1f, 0.2f, 0.5f)
-                    : Color.tan;
+                // Perlin Logic (using +halfDim to keep noise positive)
+                float perlin = Mathf.PerlinNoise((x + halfDim) * perlinScale + offsetX, (y + halfDim) * perlinScale + offsetY);
+                Color tileColor = (perlin > 0.65f) ? new Color(0.1f, 0.2f, 0.5f) : Color.tan;
 
                 squareTilemap.SetTileFlags(tilePos, TileFlags.None);
                 squareTilemap.SetColor(tilePos, tileColor);
 
-                // Track the world-space center of this tile for later spawning
-                _openTiles.Add(squareTilemap.GetCellCenterWorld(tilePos));
+                _openTiles.Add(new Vector3(x + 0.5f, y + 0.5f, 0));
             }
         }
 
@@ -100,6 +135,12 @@ public class MapGenerator2D : MonoBehaviour
         // ── Obstacle generation ───────────────────────────────────────────────
         if (obstaclePrefab != null)
             SpawnObstacles();
+
+        IsMapReady = true;
+        HasSimulationStarted = true;
+
+        // This notifies SimulationLogger and LogManager to start their work.
+        OnMapGenerated?.Invoke();
 
         // ── Initial entity spawning ───────────────────────────────────────────
         // Use Invoke so EcosystemManager and BoundaryManager have had a frame

--- a/LifeSimulation/Assets/Scripts/UIHandler.cs
+++ b/LifeSimulation/Assets/Scripts/UIHandler.cs
@@ -17,11 +17,6 @@ using System.Collections.Generic;
 /// <summary> Handles UI element and simulation interaction </summary>
 public class UIHandler : MonoBehaviour
 {
-    [Header("UI References")]
-    public TMP_InputField seedInput;
-    public TMP_InputField widthInput;
-    public TMP_InputField heightInput;
-
     [Header("Generator Reference")]
     public MapGenerator2D mapGenerator;
     [Header("Spawn Button Visibility")]
@@ -43,24 +38,13 @@ public class UIHandler : MonoBehaviour
     /// <summary> Triggers upon Map Generate button being clicked </summary>
     public void OnClickGenerate()
     {
-        // Takes string data from seed field input to be used in map generation
-        string seed = seedInput.text;
-
         if (mapGenerator == null)
         {
             return;
         }
 
-        int width = 250;
-        int height = 250;
-        if (SimulationSettingsStore.Instance != null)
-        {
-            width = SimulationSettingsStore.Instance.Current.terrain.mapWidth;
-            height = SimulationSettingsStore.Instance.Current.terrain.mapHeight;
-        }
-
         // Pass taken data to map generation script (dimensions come from saved settings, not UI fields)
-        mapGenerator.GenerateMap(seed, width, height);
+        mapGenerator.GenerateMap();
         bool started = mapGenerator.IsMapReady && mapGenerator.HasSimulationStarted;
         UpdateSpawnButtonsVisibility(started);
         SetGenerateMapButtonVisible(!started);

--- a/LifeSimulation/Assets/pixil-frame-0 (1) (1).png.meta
+++ b/LifeSimulation/Assets/pixil-frame-0 (1) (1).png.meta
@@ -1,10 +1,10 @@
 fileFormatVersion: 2
-guid: 70ce10590f8445940aa1fd7539f7e806
+guid: 6652824b67c359e46a37728180585f21
 TextureImporter:
   internalIDToNameTable:
   - first:
-      213: -5513050994037168576
-    second: pixil-frame-0 (3)_0
+      213: 358550201270088617
+    second: pixil-frame-0 (1) (1)_0
   externalObjects: {}
   serializedVersion: 13
   mipmaps:
@@ -96,17 +96,30 @@ TextureImporter:
     ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
   spriteSheet:
     serializedVersion: 2
     sprites:
     - serializedVersion: 2
-      name: pixil-frame-0 (3)_0
+      name: pixil-frame-0 (1) (1)_0
       rect:
         serializedVersion: 2
         x: 9
-        y: 9
+        y: 19
         width: 142
-        height: 142
+        height: 141
       alignment: 0
       pivot: {x: 0, y: 0}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -115,8 +128,8 @@ TextureImporter:
       physicsShape: []
       tessellationDetail: -1
       bones: []
-      spriteID: 046eccf8455bd73b0800000000000000
-      internalID: -5513050994037168576
+      spriteID: 9a339d42283d9f400800000000000000
+      internalID: 358550201270088617
       vertices: []
       indices: 
       edges: []
@@ -135,7 +148,7 @@ TextureImporter:
     spriteCustomMetadata:
       entries: []
     nameFileIdTable:
-      pixil-frame-0 (3)_0: -5513050994037168576
+      pixil-frame-0 (1) (1)_0: 358550201270088617
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 

--- a/LifeSimulation/Assets/pixil-frame-0 (2) (1).png.meta
+++ b/LifeSimulation/Assets/pixil-frame-0 (2) (1).png.meta
@@ -1,10 +1,10 @@
 fileFormatVersion: 2
-guid: 2a4335b3feece0e4b8cc35d4c89c7c2a
+guid: 034ba2da5d146f643b4818e76ade13a4
 TextureImporter:
   internalIDToNameTable:
   - first:
-      213: -3337038689812066966
-    second: pixil-frame-0_0
+      213: 7560591164928645431
+    second: pixil-frame-0 (2) (1)_0
   externalObjects: {}
   serializedVersion: 13
   mipmaps:
@@ -96,17 +96,30 @@ TextureImporter:
     ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
   spriteSheet:
     serializedVersion: 2
     sprites:
     - serializedVersion: 2
-      name: pixil-frame-0_0
+      name: pixil-frame-0 (2) (1)_0
       rect:
         serializedVersion: 2
-        x: 0
-        y: 19
-        width: 160
-        height: 141
+        x: 9
+        y: 9
+        width: 142
+        height: 132
       alignment: 0
       pivot: {x: 0, y: 0}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -115,8 +128,8 @@ TextureImporter:
       physicsShape: []
       tessellationDetail: -1
       bones: []
-      spriteID: a6d4404fdf470b1d0800000000000000
-      internalID: -3337038689812066966
+      spriteID: 73957855b9d9ce860800000000000000
+      internalID: 7560591164928645431
       vertices: []
       indices: 
       edges: []
@@ -135,7 +148,7 @@ TextureImporter:
     spriteCustomMetadata:
       entries: []
     nameFileIdTable:
-      pixil-frame-0_0: -3337038689812066966
+      pixil-frame-0 (2) (1)_0: 7560591164928645431
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 

--- a/LifeSimulation/Assets/pixil-frame-0 (3) (1).png.meta
+++ b/LifeSimulation/Assets/pixil-frame-0 (3) (1).png.meta
@@ -1,10 +1,10 @@
 fileFormatVersion: 2
-guid: 0d4efbdb5b39ab4448b58f9182b79816
+guid: 34e7e4c2e14bfb148bbfd0a3f2802e81
 TextureImporter:
   internalIDToNameTable:
   - first:
-      213: 4483504832982471387
-    second: pixil-frame-0 (1)_0
+      213: 6097263166143520310
+    second: pixil-frame-0 (3) (1)_0
   externalObjects: {}
   serializedVersion: 13
   mipmaps:
@@ -96,17 +96,30 @@ TextureImporter:
     ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
   spriteSheet:
     serializedVersion: 2
     sprites:
     - serializedVersion: 2
-      name: pixil-frame-0 (1)_0
+      name: pixil-frame-0 (3) (1)_0
       rect:
         serializedVersion: 2
         x: 9
-        y: 19
+        y: 9
         width: 142
-        height: 141
+        height: 142
       alignment: 0
       pivot: {x: 0, y: 0}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -115,8 +128,8 @@ TextureImporter:
       physicsShape: []
       tessellationDetail: -1
       bones: []
-      spriteID: bd2daa614eb983e30800000000000000
-      internalID: 4483504832982471387
+      spriteID: 63ede008b84dd9450800000000000000
+      internalID: 6097263166143520310
       vertices: []
       indices: 
       edges: []
@@ -135,7 +148,7 @@ TextureImporter:
     spriteCustomMetadata:
       entries: []
     nameFileIdTable:
-      pixil-frame-0 (1)_0: 4483504832982471387
+      pixil-frame-0 (3) (1)_0: 6097263166143520310
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 

--- a/LifeSimulation/Assets/pixil-frame-0 (4).png.meta
+++ b/LifeSimulation/Assets/pixil-frame-0 (4).png.meta
@@ -1,10 +1,10 @@
 fileFormatVersion: 2
-guid: fa23e4a29abd2284d83653330b450d7c
+guid: 862a9a67b8794e046ad207fb3249b3b9
 TextureImporter:
   internalIDToNameTable:
   - first:
-      213: -168421969075237668
-    second: pixil-frame-0 (2)_0
+      213: 2912297781628502651
+    second: pixil-frame-0 (4)_0
   externalObjects: {}
   serializedVersion: 13
   mipmaps:
@@ -96,17 +96,30 @@ TextureImporter:
     ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
   spriteSheet:
     serializedVersion: 2
     sprites:
     - serializedVersion: 2
-      name: pixil-frame-0 (2)_0
+      name: pixil-frame-0 (4)_0
       rect:
         serializedVersion: 2
-        x: 9
-        y: 9
-        width: 142
-        height: 132
+        x: 0
+        y: 19
+        width: 160
+        height: 141
       alignment: 0
       pivot: {x: 0, y: 0}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -115,8 +128,8 @@ TextureImporter:
       physicsShape: []
       tessellationDetail: -1
       bones: []
-      spriteID: cdc06e88c15a9adf0800000000000000
-      internalID: -168421969075237668
+      spriteID: b720022076f8a6820800000000000000
+      internalID: 2912297781628502651
       vertices: []
       indices: 
       edges: []
@@ -135,7 +148,7 @@ TextureImporter:
     spriteCustomMetadata:
       entries: []
     nameFileIdTable:
-      pixil-frame-0 (2)_0: -168421969075237668
+      pixil-frame-0 (4)_0: 2912297781628502651
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 


### PR DESCRIPTION
Major refactor of map generation and related UI/prefab assets:

- MapGenerator2D: changed GenerateMap to parameterless; determine map size from CameraHandler.selectedSize; initialize RNG from current time; add Perlin offsets; batch-populate tilemap using SetTilesBlock and set tile colors; populate _openTiles with world centers; set IsMapReady/HasSimulationStarted and invoke OnMapGenerated. Added file header and metadata.
- UIHandler: removed seed/width/height TMP input fields and related logic; now calls mapGenerator.GenerateMap() with dimensions sourced from CameraHandler/engine state and updates spawn button visibility accordingly.
- SimulationSettingsStore: removed code that wrote map width/height back into UI inputs when loading settings (UI no longer exposes those fields).
- Prefabs: adjusted local scales, sprite references, sprite sizes and BoxCollider2D newSize/oldSize for Placeholder_Grazer, Placeholder_Predator, Placeholder_Plant, and Placeholder_Obstacle to match updated sprites/visual scale.
- Asset metadata: renamed several pixil-frame-0 PNG meta files (new names/guids/internalIDs) and added WebGL import settings entries.
- Minor: fixed file header BOM in EnvironmentHandler.

These changes centralize map sizing and seeding, improve tilemap setup performance, simplify the UI surface, and align prefabs/assets with updated sprites.